### PR TITLE
feat: passive CLI update check with agent ask-before-update flow (0.3.2)

### DIFF
--- a/blocks-cli/AGENT_GUIDE.md
+++ b/blocks-cli/AGENT_GUIDE.md
@@ -19,6 +19,30 @@ blocks --version
 blocks --help
 ```
 
+### Check the version before working
+
+An installed CLI silently ages: commands, flags, and scaffold behavior in this
+guide describe the latest release, not whatever happens to be on the machine.
+At the start of a session, compare the installed version against the registry:
+
+```bash
+blocks --version
+npm view @seliseblocks/cli-os version
+```
+
+If the installed version is behind, tell the user both versions and ask for
+their confirmation to run `npm install -g @seliseblocks/cli-os@latest`. Never
+update on your own initiative. If they decline, continue on the old version and
+expect drift from documented flags and defaults; say so when something is
+missing rather than working around it silently.
+
+The CLI also helps from 0.3.2 onward: after each command it prints an
+`Update available` notice to stderr (checked against the registry at most once
+every 24 hours, cached in the config directory) and `blocks doctor --json`
+reports `cliVersion`, `latestCliVersion`, and `cliUpdateAvailable` from that
+cache. Treat that notice exactly like the manual check above: inform, ask,
+and only then update. Set `BLOCKS_NO_UPDATE_CHECK=1` to disable the check.
+
 For local package development only, contributors may run `node bin/run.js ...` from the source repository. AI agents consuming the npm package should use `blocks ...`.
 
 ## Global Options
@@ -134,6 +158,10 @@ proof of permission. The launcher must assign a unique session/user-specific
 `BLOCKS_CONFIG_DIR`; the CLI uses only that context and performs no VM detection.
 
 ### AI agent startup
+
+First check the CLI is current (see "Check the version before working" above):
+compare `blocks --version` with `npm view @seliseblocks/cli-os version`, and if
+it is behind, tell the user and ask before updating.
 
 For normal local work, leave `BLOCKS_CONFIG_DIR` unchanged and use the user's
 OS-scoped store. Probe with `blocks auth status --json`; if login is missing,

--- a/blocks-cli/CHANGELOG.md
+++ b/blocks-cli/CHANGELOG.md
@@ -6,6 +6,26 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Versions before 0.3.0 were released without a changelog; their history is in the
 repository's git log.
 
+## 0.3.2
+
+### Added
+
+- After every command, the CLI checks the npm registry for a newer
+  `@seliseblocks/cli-os` (at most once every 24 hours, cached in the config
+  directory as `update-check.json`) and prints an `Update available` notice to
+  stderr — stdout stays clean for `--json` parsers. The notice tells agent
+  sessions to inform the user and ask for confirmation before updating; the CLI
+  never updates itself. Set `BLOCKS_NO_UPDATE_CHECK=1` to disable.
+- `blocks doctor` gained a "CLI up to date" check and, in `--json`, top-level
+  `cliVersion`, `latestCliVersion`, and `cliUpdateAvailable` fields. It reads
+  the cached registry lookup only — doctor still makes no network request —
+  and an outdated version never fails the run, so scripts gating on doctor's
+  exit code don't break the day a release ships.
+- `blocks-bootstrap` skill and `AGENT_GUIDE.md` now instruct agents to compare
+  `blocks --version` against `npm view @seliseblocks/cli-os version` at session
+  start and ask the user before upgrading — this works even when the installed
+  CLI predates the built-in notice.
+
 ## 0.3.1
 
 ### Changed

--- a/blocks-cli/command-docs.json
+++ b/blocks-cli/command-docs.json
@@ -3,8 +3,8 @@
     "summary": "Create local Blocks workspace files: blocks.json, data schema/rules folders, and .env.example."
   },
   "doctor": {
-    "summary": "Inspect cached Node.js, OIDC config, token, optional project, and storage health.",
-    "details": "Account-only mode is valid. Performs no token refresh, network request, or state write."
+    "summary": "Inspect cached CLI version, Node.js, OIDC config, token, optional project, and storage health.",
+    "details": "Account-only mode is valid. Performs no token refresh, network request, or state write. The 'CLI up to date' check reads the daily-cached npm registry lookup; an outdated version is reported (JSON: cliUpdateAvailable) but never fails the run -- ask the user before running 'npm install -g @seliseblocks/cli-os@latest'."
   },
   "login": {
     "summary": "Device-code login.",

--- a/blocks-cli/package.json
+++ b/blocks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seliseblocks/cli-os",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "CLI for SELISE Blocks project setup and configuration.",
   "keywords": [
     "selise",

--- a/blocks-cli/src/commands/doctor.ts
+++ b/blocks-cli/src/commands/doctor.ts
@@ -5,6 +5,7 @@ import { writeOutput } from "../lib/output.js";
 import { isExpiring } from "../lib/token.js";
 import { readTokenStore, tokenPath, tokenStoreInfo } from "../lib/token-store.js";
 import { secretPath, secretStoreInfo } from "../lib/secret-store.js";
+import { installedCliVersion, isNewerVersion, readUpdateCheckCache } from "../lib/update-check.js";
 import { optionalSelectedProject } from "../lib/workspace.js";
 
 export async function doctor(argv: string[] = []): Promise<void> {
@@ -16,7 +17,22 @@ export async function doctor(argv: string[] = []): Promise<void> {
   const tenantId = await optionalSelectedProject(flags);
   let hasFailure = false;
 
+  // Latest version comes from the cache the post-command update notice
+  // maintains, never a live lookup -- doctor's contract is no network request.
+  // An empty cache (fresh install, BLOCKS_NO_UPDATE_CHECK, offline) reports
+  // the installed version alone rather than failing the check.
+  const cliVersion = await installedCliVersion();
+  const latestCliVersion = (await readUpdateCheckCache())?.latest;
+  const cliUpdateAvailable = Boolean(latestCliVersion && isNewerVersion(latestCliVersion, cliVersion));
+
   const checks: Array<{ label: string; ok: boolean; detail: string }> = [
+    {
+      label: "CLI up to date",
+      ok: !cliUpdateAvailable,
+      detail: cliUpdateAvailable
+        ? `${cliVersion} (latest ${latestCliVersion}; ask the user before running 'npm install -g @seliseblocks/cli-os@latest')`
+        : `${cliVersion}${latestCliVersion ? ` (latest ${latestCliVersion})` : " (latest unknown: no cached registry check yet)"}`
+    },
     { label: "Node.js >= 20", ok: Number(process.versions.node.split(".")[0]) >= 20, detail: process.version },
     { label: "OIDC account configured", ok: Object.keys(config.accounts).length > 0, detail: config.activeAccount ?? "missing" }
   ];
@@ -77,11 +93,14 @@ export async function doctor(argv: string[] = []): Promise<void> {
   );
 
   for (const check of checks) {
-    if (!check.ok) hasFailure = true;
+    // An outdated CLI is worth flagging but is not a broken install: scripts
+    // and agents gating on doctor's exit code must not start failing the day
+    // a new version is published.
+    if (!check.ok && check.label !== "CLI up to date") hasFailure = true;
   }
 
   if (flags.json) {
-    writeOutput({ ok: !hasFailure, checks }, flags);
+    writeOutput({ ok: !hasFailure, cliVersion, latestCliVersion: latestCliVersion ?? null, cliUpdateAvailable, checks }, flags);
   } else {
     for (const check of checks) {
       console.log(`${check.ok ? "ok" : "missing"}  ${check.label}  ${check.detail}`);

--- a/blocks-cli/src/index.ts
+++ b/blocks-cli/src/index.ts
@@ -208,6 +208,7 @@ import { storageConfigList } from "./commands/storage/config/list.js";
 import { storageConfigSave } from "./commands/storage/config/save.js";
 import type { CommandEntry } from "./lib/command-catalog.js";
 import { CliActionableError } from "./lib/errors.js";
+import { maybePrintUpdateNotice } from "./lib/update-check.js";
 import {
   findCommand,
   renderCommand,
@@ -512,6 +513,11 @@ try {
   process.exitCode = 1;
 }
 
+// After the command, success or failure alike: a failed command is the moment
+// an outdated install matters most (unknown command/flag), and stderr keeps it
+// out of any --json stdout being parsed.
+await maybePrintUpdateNotice();
+
 /**
  * Says something when a command was handed a flag it will never read.
  *
@@ -591,15 +597,23 @@ Global options:
   --dry-run                 Show planned mutation without calling the API.
   --yes                     Skip mutation confirmation after explicit approval.
 
+Update notice:
+  After a command finishes, the CLI checks the npm registry for a newer
+  @seliseblocks/cli-os at most once every 24 hours (cached in the config
+  directory) and prints a notice to stderr when one exists. It never updates
+  anything itself. Set BLOCKS_NO_UPDATE_CHECK=1 to disable the check.
+
 Setup and health:
   blocks init
     Create local Blocks workspace files: blocks.json, data schema/rules folders,
     and .env.example.
 
   blocks doctor [--json]
-    Inspect cached Node.js, OIDC config, token, optional project, and storage
-    health. Account-only mode is valid. Performs no token refresh, network
-    request, or state write.
+    Inspect cached CLI version, Node.js, OIDC config, token, optional project,
+    and storage health. Account-only mode is valid. Performs no token refresh,
+    network request, or state write; the "CLI up to date" check reads the
+    cached daily registry lookup (see 'Update notice' above) and never fails
+    the run.
 
 Auth:
   blocks login [--account <name>]

--- a/blocks-cli/src/lib/command-catalog.ts
+++ b/blocks-cli/src/lib/command-catalog.ts
@@ -561,7 +561,6 @@ export const commandCatalog: readonly CommandEntry[] = [
     "mutating": false,
     "flags": [
       "name",
-      "page",
       "page-size",
       "sort-by",
       "sort-desc",
@@ -1100,8 +1099,8 @@ export const commandCatalog: readonly CommandEntry[] = [
   {
     "name": "doctor",
     "family": "doctor",
-    "summary": "Inspect cached Node.js, OIDC config, token, optional project, and storage health.",
-    "details": "Account-only mode is valid. Performs no token refresh, network request, or state write.",
+    "summary": "Inspect cached CLI version, Node.js, OIDC config, token, optional project, and storage health.",
+    "details": "Account-only mode is valid. Performs no token refresh, network request, or state write. The 'CLI up to date' check reads the daily-cached npm registry lookup; an outdated version is reported (JSON: cliUpdateAvailable) but never fails the run -- ask the user before running 'npm install -g @seliseblocks/cli-os@latest'.",
     "scope": "local",
     "mutating": false,
     "flags": []

--- a/blocks-cli/src/lib/update-check.ts
+++ b/blocks-cli/src/lib/update-check.ts
@@ -1,0 +1,108 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { configDir } from "./config.js";
+
+// Agent sessions keep running whatever CLI version was installed months ago and
+// never find out a newer one exists until a flag or command is missing. This
+// module closes that gap passively: at most once a day it asks the npm registry
+// for the latest published version, caches the answer next to the CLI config,
+// and prints a short stderr notice on every command while the installed version
+// is behind. It only ever informs -- updating stays a user decision.
+const PACKAGE_NAME = "@seliseblocks/cli-os";
+const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 2000;
+const CACHE_FILE = "update-check.json";
+
+export type UpdateCheckCache = { checkedAt: string; latest: string };
+
+export async function installedCliVersion(): Promise<string> {
+  const packageUrl = new URL("../../package.json", import.meta.url);
+  const pkg = JSON.parse(await readFile(packageUrl, "utf8")) as { version?: string };
+  return pkg.version ?? "0.0.0";
+}
+
+/** Cached result of the last registry lookup, if one has ever completed. */
+export async function readUpdateCheckCache(): Promise<UpdateCheckCache | undefined> {
+  try {
+    const raw = JSON.parse(await readFile(join(configDir(), CACHE_FILE), "utf8")) as UpdateCheckCache;
+    return typeof raw?.latest === "string" && typeof raw?.checkedAt === "string" ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * True when `candidate` is a strictly newer semver than `current`. Prerelease
+ * tags are compared only as "a prerelease of X is older than plain X" -- the
+ * registry's `latest` dist-tag never points at a prerelease, so finer ordering
+ * would be dead code here.
+ */
+export function isNewerVersion(candidate: string, current: string): boolean {
+  const parse = (version: string): { parts: number[]; prerelease: boolean } => {
+    const [core, prerelease] = version.split("-", 2);
+    const parts = core.split(".").map((part) => Number.parseInt(part, 10));
+    return { parts: [parts[0] || 0, parts[1] || 0, parts[2] || 0], prerelease: Boolean(prerelease) };
+  };
+
+  const next = parse(candidate);
+  const now = parse(current);
+  for (let index = 0; index < 3; index++) {
+    if (next.parts[index] !== now.parts[index]) return next.parts[index] > now.parts[index];
+  }
+  return now.prerelease && !next.prerelease;
+}
+
+async function fetchLatestVersion(): Promise<string | undefined> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(REGISTRY_URL, { signal: controller.signal });
+    if (!response.ok) return undefined;
+    const body = (await response.json()) as { version?: string };
+    return typeof body.version === "string" && /^\d+\.\d+\.\d+/.test(body.version) ? body.version : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function latestKnownVersion(): Promise<string | undefined> {
+  const cached = await readUpdateCheckCache();
+  if (cached && Date.now() - Date.parse(cached.checkedAt) < CHECK_INTERVAL_MS) return cached.latest;
+
+  const latest = await fetchLatestVersion();
+  if (!latest) return cached?.latest;
+
+  try {
+    await mkdir(configDir(), { recursive: true });
+    const cache: UpdateCheckCache = { checkedAt: new Date().toISOString(), latest };
+    await writeFile(join(configDir(), CACHE_FILE), `${JSON.stringify(cache)}\n`);
+  } catch {
+    // A cache that cannot be written just means the next command re-fetches.
+  }
+  return latest;
+}
+
+/**
+ * Runs after every command from the entry point. stderr only, so a --json
+ * document being piped into a parser is never touched, and every failure mode
+ * (offline, registry down, unwritable config dir) is silent -- an update
+ * notice must never break or slow the command the user actually ran beyond
+ * the one short registry timeout a day.
+ */
+export async function maybePrintUpdateNotice(): Promise<void> {
+  if (process.env.BLOCKS_NO_UPDATE_CHECK) return;
+  try {
+    const current = await installedCliVersion();
+    const latest = await latestKnownVersion();
+    if (!latest || !isNewerVersion(latest, current)) return;
+
+    console.error(`\nUpdate available: ${PACKAGE_NAME} ${current} -> ${latest}.`);
+    console.error(`Run 'npm install -g ${PACKAGE_NAME}@latest' to update.`);
+    console.error("Agent sessions: tell the user a newer CLI is published and ask for their confirmation before updating. Never update on your own.");
+  } catch {
+    // Never let the update check surface as a command failure.
+  }
+}

--- a/blocks-cli/test/cli.test.mjs
+++ b/blocks-cli/test/cli.test.mjs
@@ -20,9 +20,26 @@ import {
 import { withAuthTransitionLock } from "../dist/lib/auth-lock.js";
 import { CliActionableError } from "../dist/lib/errors.js";
 import { oidcRedirectUrisFromAppDomain } from "../dist/lib/domains.js";
+import { isNewerVersion } from "../dist/lib/update-check.js";
 
 const repoRoot = resolve(import.meta.dirname, "..");
 const bin = join(repoRoot, "bin", "run.js");
+
+// Every spawned CLI inherits process.env, so this keeps the post-command
+// update notice from making live npm registry calls throughout the suite.
+// Tests that exercise the notice itself override it with an empty value.
+process.env.BLOCKS_NO_UPDATE_CHECK = "1";
+
+test("isNewerVersion orders semver correctly", () => {
+  assert.equal(isNewerVersion("0.4.0", "0.3.1"), true);
+  assert.equal(isNewerVersion("0.3.2", "0.3.1"), true);
+  assert.equal(isNewerVersion("1.0.0", "0.9.9"), true);
+  assert.equal(isNewerVersion("0.3.1", "0.3.1"), false);
+  assert.equal(isNewerVersion("0.3.0", "0.3.1"), false);
+  assert.equal(isNewerVersion("0.3.1", "0.10.0"), false);
+  assert.equal(isNewerVersion("0.4.0", "0.4.0-beta.1"), true);
+  assert.equal(isNewerVersion("0.4.0-beta.1", "0.4.0"), false);
+});
 
 test("account token refresh preserves the previous refresh token when the response omits one", () => {
   const store = {
@@ -2899,6 +2916,70 @@ test("doctor accepts a healthy account-only session without a selected project",
   const output = JSON.parse(result.stdout);
   assert.equal(output.ok, true);
   assert.ok(output.checks.some((check) => check.label === "Project context" && /account-only mode/.test(check.detail)));
+});
+
+test("doctor reports an available CLI update from the cached check without failing", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeConfig(configDir, {
+    activeAccount: "default",
+    accounts: { default: testAccountProfile("root-tenant") }
+  });
+  await writeFile(join(configDir, "tokens.json"), `${JSON.stringify({
+    accounts: {
+      default: {
+        account: {
+          accessToken: fakeJwt({ exp: Math.floor(Date.now() / 1000) + 3600, tenant_id: "root-tenant" }),
+          accountTenant: "root-tenant",
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          refreshToken: "account-refresh"
+        }
+      }
+    }
+  })}\n`);
+  await writeSecretStore(configDir, { accounts: {} });
+  await writeFile(join(configDir, "update-check.json"), `${JSON.stringify({
+    checkedAt: new Date().toISOString(),
+    latest: "99.0.0"
+  })}\n`);
+
+  const result = run(["doctor", "--account", "default", "--json"], {
+    cwd,
+    env: testEnv(configDir, { BLOCKS_SECRET_STORE: "file" })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.ok, true, "an outdated CLI must not fail an otherwise healthy doctor run");
+  assert.equal(output.cliUpdateAvailable, true);
+  assert.equal(output.latestCliVersion, "99.0.0");
+  const versionCheck = output.checks.find((check) => check.label === "CLI up to date");
+  assert.equal(versionCheck.ok, false);
+  assert.match(versionCheck.detail, /ask the user/);
+});
+
+test("update notice prints on stderr when the cached latest version is newer", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeFile(join(configDir, "update-check.json"), `${JSON.stringify({
+    checkedAt: new Date().toISOString(),
+    latest: "99.0.0"
+  })}\n`);
+
+  // A fresh cache is served without a registry call, so clearing the opt-out
+  // here still keeps the test offline.
+  const result = run(["--version"], {
+    cwd,
+    env: testEnv(configDir, { BLOCKS_NO_UPDATE_CHECK: "" })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout.trim(), /^\d+\.\d+\.\d+/, "stdout stays a bare version for parsers");
+  assert.match(result.stderr, /Update available: @seliseblocks\/cli-os .* -> 99\.0\.0/);
+  assert.match(result.stderr, /ask for their confirmation before updating/i);
+
+  const silenced = run(["--version"], {
+    cwd,
+    env: testEnv(configDir, { BLOCKS_NO_UPDATE_CHECK: "1" })
+  });
+  assert.equal(silenced.status, 0, silenced.stderr);
+  assert.ok(!silenced.stderr.includes("Update available"), "BLOCKS_NO_UPDATE_CHECK must silence the notice");
 });
 
 test("projects create stops and restores an active project session", async () => {

--- a/blocks-skills/blocks-bootstrap/SKILL.md
+++ b/blocks-skills/blocks-bootstrap/SKILL.md
@@ -25,10 +25,11 @@ Once the CLI is logged in, a project is selected, and the user is asking for a s
 
 ## State detection — probe, don't interrogate
 
-Run all three before asking the user anything. None of them mutates, and none prints a token value.
+Run all four before asking the user anything. None of them mutates, and none prints a token value. (`npm view` is a public registry lookup; if it fails offline, continue without the comparison.)
 
 ```bash
 blocks --version
+npm view @seliseblocks/cli-os version
 blocks auth status --json
 blocks doctor --json
 ```
@@ -47,6 +48,7 @@ normal project mode, not a broken login. Read it like this:
 | Signal | State | Do this |
 |---|---|---|
 | `blocks --version` fails with command not found | CLI not installed | Ask before installing `npm install -g @seliseblocks/cli-os@latest`, then re-probe |
+| `blocks --version` is behind `npm view @seliseblocks/cli-os version` | CLI outdated | Tell the user both versions and ask confirmation to run `npm install -g @seliseblocks/cli-os@latest`; never update without a yes. If they decline, continue on the old version and expect missing commands/flags/defaults relative to these skills — name the gap instead of silently working around it |
 | All four tokens `missing` | No login in this resolved context | Local: `blocks login --account <name>`; Studio: report missing launcher bootstrap/context |
 | Account AT and RT valid/available; project pair missing | Account mode | List/select a project or perform an account-only operation |
 | `accountAccessToken` `expired`, `accountRefreshToken` `valid` | Recoverable | `blocks auth refresh --json`, then re-probe |
@@ -61,6 +63,8 @@ normal project mode, not a broken login. Read it like this:
 project mode is usable only when its project token pair is present. Do not
 require an account pair simultaneously: impersonation replaces it, and
 `blocks deselect` exchanges the project pair for a fresh account pair.
+
+From CLI 0.3.2 onward, any command may print an `Update available` notice on stderr, and `blocks doctor --json` reports `cliUpdateAvailable`. Treat either exactly like the version comparison above: inform the user, ask for confirmation, and only then update.
 
 Use `blocks doctor --json` when something looks broken rather than merely undone — it checks Node version, credential storage backend, account and project token freshness in one pass. Its `detail` fields include the paths of the CLI's config and secret files. That is diagnostic output, not an invitation: never open, read, print, or quote those files. Interact with them only through `blocks` commands.
 


### PR DESCRIPTION
After every command the CLI checks npm for a newer @seliseblocks/cli-os (cached 24h in the config dir) and prints a stderr notice instructing agent sessions to inform the user and ask confirmation before updating. Doctor gains an offline "CLI up to date" check with cliVersion / latestCliVersion / cliUpdateAvailable in --json that never fails the run. Bootstrap skill and AGENT_GUIDE now compare blocks --version against npm view at session start so even old installs get caught. BLOCKS_NO_UPDATE_CHECK=1 disables the check.