### PR TITLE
fix(auth): fail closed on native credential stores (0.3.3)

### DIFF
--- a/blocks-cli/CHANGELOG.md
+++ b/blocks-cli/CHANGELOG.md
@@ -6,6 +6,40 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Versions before 0.3.0 were released without a changelog; their history is in the
 repository's git log.
 
+## 0.3.3
+
+### Fixed
+
+- Native credential writes (macOS Keychain, Linux Secret Service, Windows
+  DPAPI) are verified by reading the value back before the CLI reports
+  success. Previously `security add-generic-password` could exit 0 while
+  storing an empty password (its prompt reads the terminal, not the stdin
+  pipe), after which the CLI deleted `tokens.json` and `blocks login` printed
+  `Login done.` on a machine that had just lost its tokens. A write that does
+  not round-trip now fails with `secret_store_write_failed` and the next step
+  `Set BLOCKS_SECRET_STORE=file`, and `tokens.json` is only removed after the
+  native store has proven it holds the tokens.
+- Migrating an existing `tokens.json` into a native credential store (which
+  happens on the read path) is best-effort: when the native write fails, the
+  CLI warns on stderr and keeps serving the file instead of destroying the
+  only readable copy or failing the command.
+- A stale or manually created entry occupying the CLI's credential-store slot
+  surfaces as an actionable `token_store_unreadable` error instead of crashing
+  every command with a raw `SyntaxError`.
+- The macOS Keychain write uses the argv form of
+  `security add-generic-password -w` again -- the stdin form did not
+  round-trip on real Macs (see above). The token payload is escaped to plain
+  ASCII before storage so `security`'s hex-dumping of non-ASCII data cannot
+  fail verification for stores containing unicode account or project names.
+
+### Added
+
+- `BLOCKS_SECRET_STORE` also accepts `windows-dpapi`, `macos-keychain`, and
+  `linux-secret-service` to force a specific native backend. The test suite
+  uses this to exercise the native code paths deterministically; write
+  verification makes a wrong override fail loudly rather than lose
+  credentials.
+
 ## 0.3.2
 
 ### Added

--- a/blocks-cli/package.json
+++ b/blocks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seliseblocks/cli-os",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "CLI for SELISE Blocks project setup and configuration.",
   "keywords": [
     "selise",

--- a/blocks-cli/src/lib/secret-store.ts
+++ b/blocks-cli/src/lib/secret-store.ts
@@ -5,6 +5,7 @@ import { platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { configDir } from "./config.js";
+import { CliActionableError } from "./errors.js";
 
 const execFileAsync = promisify(execFile);
 const SERVICE = "seliseblocks-cli";
@@ -66,8 +67,15 @@ export async function getClientSecret(account: string): Promise<string | undefin
 
   const backend = await resolveBackend();
   if (backend !== "file") {
-    await setSecretValue(key, fallback);
-    await removeFallbackSecret(account);
+    // Promotion into the native store is opportunistic: this is a read that
+    // already has the value, so a broken native backend must not turn it into
+    // a failure. The fallback entry stays until a promotion round-trips.
+    try {
+      await setSecretValue(key, fallback);
+      await removeFallbackSecret(account);
+    } catch {
+      // keep serving the fallback copy
+    }
   }
 
   return fallback;
@@ -92,7 +100,18 @@ export async function setSecretValue(key: string, value: string): Promise<void> 
   }
 
   if (backend === "windows-dpapi") {
-    const encrypted = await protectWindowsSecret(value);
+    // Encrypt-then-decrypt before anything is persisted: a PowerShell or DPAPI
+    // profile problem must fail the write loudly instead of storing a blob
+    // that can never be read back (which looks like "logged out" later).
+    let encrypted: string;
+    try {
+      encrypted = await protectWindowsSecret(value);
+    } catch (error) {
+      throw secretWriteFailed("Windows DPAPI", error);
+    }
+    if (await unprotectWindowsSecret(encrypted) !== value) {
+      throw secretWriteFailed("Windows DPAPI");
+    }
     const store = await readSecretStore();
     await writeSecretStore({
       accounts: {
@@ -171,7 +190,13 @@ function normalizeSecretStore(store?: Partial<BlocksSecretStore>): BlocksSecretS
 }
 
 async function resolveBackend(): Promise<SecretBackend> {
-  if (process.env.BLOCKS_SECRET_STORE === "file") return "file";
+  const forced = process.env.BLOCKS_SECRET_STORE;
+  if (forced === "file") return "file";
+  // An explicit native backend skips platform detection and probing. This is
+  // how the test suite exercises the native code paths deterministically on
+  // any OS; write verification below makes a wrong override fail loudly
+  // rather than silently losing credentials.
+  if (forced === "windows-dpapi" || forced === "macos-keychain" || forced === "linux-secret-service") return forced;
   if (platform() === "win32") return "windows-dpapi";
   // Probed rather than assumed, the same way secret-tool is on Linux: on a
   // machine where `security` is missing or blocked by policy, claiming the
@@ -222,23 +247,24 @@ async function unprotectWindowsSecret(secret: string): Promise<string | undefine
 }
 
 /**
- * Writes through stdin, not argv. `security add-generic-password -w <secret>`
- * puts the credential in the process's argument list, where any process running
- * as the same user can read it out of `ps` for as long as the call lasts -- and
- * argv is easier to read than the environment block. Passing `-w` with no value
- * makes `security` read the password from stdin instead, which is how the Linux
- * `secret-tool` path already works.
- *
- * Falls back to the argv form if the stdin form fails, so a `security` build
- * that insists on a terminal for the prompt still stores the secret rather than
- * failing the login outright.
+ * Writes through argv (`-w <secret>`) and then reads the item back before
+ * reporting success. An earlier revision piped the secret to `security` on
+ * stdin (`-w` with no value) to keep it out of the process argument list, but
+ * on a real Mac that form does not round-trip: `security` prompts the
+ * controlling terminal (`/dev/tty`), ignores the pipe, stores an EMPTY
+ * password, and still exits 0 -- so logins reported success while the tokens
+ * were already gone. The argv exposure lasts only for the life of the
+ * short-lived `security` call; a write that cannot be read back throws instead
+ * of pretending it worked.
  */
 async function setMacSecret(account: string, secret: string): Promise<void> {
-  const args = ["add-generic-password", "-a", nativeSecretAccount(account), "-s", SERVICE, "-U", "-w"];
   try {
-    await spawnWithInput("security", args, secret);
-  } catch {
-    await execFileAsync("security", [...args, secret]);
+    await execFileAsync("security", ["add-generic-password", "-a", nativeSecretAccount(account), "-s", SERVICE, "-U", "-w", secret]);
+  } catch (error) {
+    throw secretWriteFailed("macOS Keychain", error);
+  }
+  if (await getMacSecret(account) !== secret) {
+    throw secretWriteFailed("macOS Keychain");
   }
 }
 
@@ -258,7 +284,16 @@ async function removeMacSecret(account: string): Promise<void> {
 
 async function setLinuxSecret(account: string, secret: string): Promise<void> {
   const namespacedAccount = nativeSecretAccount(account);
-  await spawnWithInput("secret-tool", ["store", "--label", `Blocks CLI ${namespacedAccount}`, "service", SERVICE, "account", namespacedAccount], secret);
+  try {
+    await spawnWithInput("secret-tool", ["store", "--label", `Blocks CLI ${namespacedAccount}`, "service", SERVICE, "account", namespacedAccount], secret);
+  } catch (error) {
+    throw secretWriteFailed("Linux Secret Service", error);
+  }
+  // Exit 0 is not proof the secret landed (a locked or misbehaving keyring can
+  // still report success), so only a successful read-back counts.
+  if (await getLinuxSecret(account) !== secret) {
+    throw secretWriteFailed("Linux Secret Service");
+  }
 }
 
 async function getLinuxSecret(account: string): Promise<string | undefined> {
@@ -273,6 +308,20 @@ async function getLinuxSecret(account: string): Promise<string | undefined> {
 async function removeLinuxSecret(account: string): Promise<void> {
   if (platform() !== "linux") return;
   await execFileAsync("secret-tool", ["clear", "service", SERVICE, "account", nativeSecretAccount(account)]);
+}
+
+/**
+ * Every native write is verified by reading the value back; this is the error
+ * for a write that did not persist. The message carries the backend name and
+ * the underlying tool error only -- never the secret itself.
+ */
+function secretWriteFailed(backend: string, cause?: unknown): CliActionableError {
+  const detail = cause instanceof Error && cause.message ? `: ${cause.message}` : ".";
+  return new CliActionableError(
+    `Could not save credentials -- the ${backend} write did not persist${detail} Existing local auth state was left untouched.`,
+    "secret_store_write_failed",
+    "Set BLOCKS_SECRET_STORE=file to use the 0600-file store, then retry."
+  );
 }
 
 function nativeSecretAccount(account: string): string {

--- a/blocks-cli/src/lib/token-store.ts
+++ b/blocks-cli/src/lib/token-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { configDir, configPath, TokenSet } from "./config.js";
+import { CliActionableError } from "./errors.js";
 import { getSecretValue, secretStoreInfo, setSecretValue } from "./secret-store.js";
 
 export type AccountTokenStore = {
@@ -30,12 +31,24 @@ export async function tokenStoreInfo(): Promise<{ backend: string; detail: strin
 
 export async function readTokenStore(): Promise<BlocksTokenStore> {
   const secured = await getSecretValue(TOKEN_SECRET_KEY);
-  if (secured) return normalizeTokenStore(JSON.parse(secured) as Partial<BlocksTokenStore>);
+  if (secured) {
+    try {
+      return normalizeTokenStore(JSON.parse(secured) as Partial<BlocksTokenStore>);
+    } catch {
+      // A stale or manually created credential-store entry in the CLI's slot
+      // must surface as an actionable problem, not a raw SyntaxError crash.
+      throw new CliActionableError(
+        "The OS credential store returned data that is not a Blocks token store. A stale or manually created entry may be occupying the CLI's slot.",
+        "token_store_unreadable",
+        `Remove the '${TOKEN_SECRET_KEY}' entry for service 'seliseblocks-cli' from the OS credential store (or set BLOCKS_SECRET_STORE=file), then run 'blocks login'.`
+      );
+    }
+  }
 
   try {
     const legacy = normalizeTokenStore(JSON.parse(await readFile(tokenPath(), "utf8")) as Partial<BlocksTokenStore>);
     if ((await secretStoreInfo()).backend !== "file") {
-      await writeTokenStore(legacy);
+      await migrateTokenStoreBestEffort(legacy);
     }
     return legacy;
   } catch (error) {
@@ -45,15 +58,33 @@ export async function readTokenStore(): Promise<BlocksTokenStore> {
   const migrated = await readLegacyTokens();
   const normalized = normalizeTokenStore(migrated);
   if (migrated && (await secretStoreInfo()).backend !== "file") {
-    await writeTokenStore(normalized);
+    await migrateTokenStoreBestEffort(normalized);
   }
   return normalized;
+}
+
+/**
+ * Migrating file-based tokens into a native store happens on the READ path, so
+ * it must never take a command down or destroy the only readable copy: on a
+ * failed native write, `writeTokenStore` throws before `tokens.json` is
+ * removed, and this keeps serving the file until a migration round-trips.
+ */
+async function migrateTokenStoreBestEffort(store: BlocksTokenStore): Promise<void> {
+  try {
+    await writeTokenStore(store);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`Warning: could not migrate tokens into the OS credential store (${detail}) Continuing with the existing token file.`);
+  }
 }
 
 export async function writeTokenStore(store: BlocksTokenStore): Promise<void> {
   const info = await secretStoreInfo();
   if (info.backend !== "file") {
-    await setSecretValue(TOKEN_SECRET_KEY, JSON.stringify(normalizeTokenStore(store)));
+    // setSecretValue verifies the write by reading it back and throws when the
+    // round-trip fails, so tokens.json below is only ever removed once the
+    // native store has proven it holds the tokens.
+    await setSecretValue(TOKEN_SECRET_KEY, toAsciiJson(normalizeTokenStore(store)));
     await rm(tokenPath(), { force: true });
     return;
   }
@@ -69,6 +100,17 @@ export async function removeAccountTokens(account: string): Promise<void> {
 
   const { [account]: _, ...accounts } = store.accounts;
   await writeTokenStore({ accounts });
+}
+
+/**
+ * JSON with every non-ASCII character escaped to \uXXXX. `security
+ * find-generic-password -w` hex-dumps values holding non-ASCII bytes, which
+ * would make the write verification reject an otherwise good store (a project
+ * name can be unicode even though the tokens themselves are base64url ASCII).
+ * The escaped form parses to the identical object.
+ */
+function toAsciiJson(store: BlocksTokenStore): string {
+  return JSON.stringify(store).replace(/[\u007f-\uffff]/g, (ch) => `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`);
 }
 
 function normalizeTokenStore(store?: Partial<BlocksTokenStore>): BlocksTokenStore {

--- a/blocks-cli/test/cli.test.mjs
+++ b/blocks-cli/test/cli.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { createServer } from "node:http";
 import test from "node:test";
@@ -3237,6 +3237,163 @@ test("secret-bearing dry-runs all route through the shared redaction helper", as
     assert.doesNotMatch(result.stdout, leak, `${args[0]} leaked a secret into dry-run output`);
     if (stillReadable) stillReadable(request);
   }
+});
+
+// --- Native secret-store write verification ---------------------------------
+// Regression tests for the macOS incident where `security add-generic-password`
+// exited 0 without persisting the tokens: the CLI deleted tokens.json, reported
+// "Login done.", and every later command saw a logged-out machine. The store
+// must fail closed: a native write only counts once it reads back, and the
+// file copy survives until then.
+
+const requiresPosixShell = process.platform === "win32" && "requires a POSIX fake `security` on PATH";
+
+function sampleTokenStore() {
+  return {
+    accounts: {
+      default: {
+        account: {
+          accessToken: "access-token",
+          accountTenant: "root-tenant",
+          expiresAt: "2030-01-01T00:00:00.000Z",
+          refreshToken: "refresh-token",
+          tokenType: "Bearer"
+        }
+      }
+    }
+  };
+}
+
+async function withSecretStoreSandbox(run) {
+  const { configDir } = await makeWorkspace();
+  const original = {
+    configDir: process.env.BLOCKS_CONFIG_DIR,
+    path: process.env.PATH,
+    secretStore: process.env.BLOCKS_SECRET_STORE
+  };
+  process.env.BLOCKS_CONFIG_DIR = configDir;
+
+  try {
+    await run(configDir);
+  } finally {
+    restoreEnv("BLOCKS_CONFIG_DIR", original.configDir);
+    restoreEnv("PATH", original.path);
+    restoreEnv("BLOCKS_SECRET_STORE", original.secretStore);
+  }
+}
+
+function restoreEnv(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+async function writeFakeSecurity(configDir, script) {
+  const fakeBin = join(configDir, "fake-bin");
+  await mkdir(fakeBin, { recursive: true });
+  await writeFile(join(fakeBin, "security"), script, { mode: 0o755 });
+  process.env.PATH = `${fakeBin}${delimiter}${process.env.PATH}`;
+}
+
+test("a native credential write that cannot persist fails loudly and leaves tokens.json untouched", async () => {
+  await withSecretStoreSandbox(async (configDir) => {
+    process.env.BLOCKS_SECRET_STORE = "file";
+    await writeTokenStore(sampleTokenStore());
+
+    // No `security` anywhere on this PATH, so the forced Keychain backend
+    // cannot persist anything -- the write must throw, not pretend.
+    const emptyDir = join(configDir, "empty-path");
+    await mkdir(emptyDir, { recursive: true });
+    process.env.BLOCKS_SECRET_STORE = "macos-keychain";
+    process.env.PATH = emptyDir;
+
+    await assert.rejects(() => writeTokenStore(sampleTokenStore()), (error) => {
+      assert.ok(error instanceof CliActionableError);
+      assert.equal(error.code, "secret_store_write_failed");
+      return true;
+    });
+
+    const kept = JSON.parse(await readFile(join(configDir, "tokens.json"), "utf8"));
+    assert.equal(kept.accounts.default.account.accessToken, "access-token");
+
+    // Reads survive too: migration into the broken store is best-effort and
+    // keeps serving the file copy.
+    const read = await readTokenStore();
+    assert.equal(read.accounts.default.account.refreshToken, "refresh-token");
+  });
+});
+
+test("a Keychain write that exits 0 but stores nothing fails instead of deleting tokens.json", { skip: requiresPosixShell }, async () => {
+  await withSecretStoreSandbox(async (configDir) => {
+    process.env.BLOCKS_SECRET_STORE = "file";
+    await writeTokenStore(sampleTokenStore());
+
+    // The incident's exact shape: every `security` call reports success, no
+    // data lands, so only the read-back can catch it.
+    await writeFakeSecurity(configDir, "#!/bin/sh\nexit 0\n");
+    process.env.BLOCKS_SECRET_STORE = "macos-keychain";
+
+    await assert.rejects(() => writeTokenStore(sampleTokenStore()), (error) => {
+      assert.ok(error instanceof CliActionableError);
+      assert.equal(error.code, "secret_store_write_failed");
+      return true;
+    });
+
+    const kept = JSON.parse(await readFile(join(configDir, "tokens.json"), "utf8"));
+    assert.equal(kept.accounts.default.account.refreshToken, "refresh-token");
+  });
+});
+
+test("a Keychain write that round-trips replaces tokens.json as before", { skip: requiresPosixShell }, async () => {
+  await withSecretStoreSandbox(async (configDir) => {
+    process.env.BLOCKS_SECRET_STORE = "file";
+    await writeTokenStore(sampleTokenStore());
+
+    // A working keychain, faked with a file: add stores the last argument,
+    // find prints it back. Verification must pass and behavior must match the
+    // pre-fix contract (tokens.json handed over to the native store).
+    process.env.FAKE_SECURITY_STORE = join(configDir, "fake-keychain-item");
+    await writeFakeSecurity(configDir, [
+      "#!/bin/sh",
+      "case \"$1\" in",
+      "  add-generic-password) for last; do :; done; printf '%s' \"$last\" > \"$FAKE_SECURITY_STORE\";;",
+      "  find-generic-password) cat \"$FAKE_SECURITY_STORE\" 2>/dev/null;;",
+      "esac",
+      "exit 0",
+      ""
+    ].join("\n"));
+    process.env.BLOCKS_SECRET_STORE = "macos-keychain";
+
+    try {
+      await writeTokenStore(sampleTokenStore());
+      await assert.rejects(() => readFile(join(configDir, "tokens.json"), "utf8"), { code: "ENOENT" });
+
+      const read = await readTokenStore();
+      assert.equal(read.accounts.default.account.accessToken, "access-token");
+    } finally {
+      delete process.env.FAKE_SECURITY_STORE;
+    }
+  });
+});
+
+test("garbage occupying the CLI's credential-store slot surfaces an actionable error, not a crash", { skip: requiresPosixShell }, async () => {
+  await withSecretStoreSandbox(async (configDir) => {
+    // A manually created keychain entry (the incident had a stray password in
+    // the CLI's slot) must not take every command down with a SyntaxError.
+    await writeFakeSecurity(configDir, [
+      "#!/bin/sh",
+      "if [ \"$1\" = \"find-generic-password\" ]; then echo \"Parsa2000\"; fi",
+      "exit 0",
+      ""
+    ].join("\n"));
+    process.env.BLOCKS_SECRET_STORE = "macos-keychain";
+
+    await assert.rejects(() => readTokenStore(), (error) => {
+      assert.ok(error instanceof CliActionableError);
+      assert.equal(error.code, "token_store_unreadable");
+      assert.match(error.nextStep, /BLOCKS_SECRET_STORE=file/);
+      return true;
+    });
+  });
 });
 
 async function makeWorkspace() {


### PR DESCRIPTION
Native secret writes (macOS Keychain, Linux Secret Service, Windows DPAPI) are now verified by reading the value back before reporting success. The macOS stdin write form stored an empty password with exit 0 (security prompts /dev/tty, not the pipe), after which the CLI deleted tokens.json and login printed 'Login done.' on a machine that had just lost its tokens.

- macOS write uses the argv form again; success = read-back match, else CliActionableError secret_store_write_failed with BLOCKS_SECRET_STORE=file as the next step
- DPAPI round-trips encrypt/decrypt before persisting; secret-tool writes are read back too
- tokens.json is only removed after the native store proves it holds the tokens; read-path migration is best-effort and keeps serving the file
- garbage occupying the CLI's credential slot surfaces as actionable token_store_unreadable instead of a SyntaxError crash
- token payload is escaped to ASCII so unicode names cannot fail verification
- BLOCKS_SECRET_STORE accepts native backend names as a deterministic test seam; regression tests cover the incident shapes with a fake 'security'