### PR TITLE
fix(cli): merge-preserving saves, sparse users update, route fixes (0…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ This is the AI entry point for the repository.
 * Create Blocks projects only through `blocks projects create` (single `dev` environment, after the user agrees - it accepts the Blocks terms on their behalf), never through raw project APIs. Adding environments to an existing project is portal-only.
 * Never expose secrets or credentials.
 * Ask for approval before destructive or cloud-mutating operations.
+* After changing any CLI endpoint or any `blocks-*/server` contract, run `npm run verify:endpoints` in `blocks-cli/` -- it checks every CLI route+verb against the checked-out service controllers (this is how a stale `/api` base and a wrong Storage/Delete verb were caught). It verifies routes only; DTO field names, FromQuery/FromBody binding and replace-vs-patch semantics still need the server source read, and any skill prose stating endpoint behavior must be re-checked at the same time (0.4.1: two skills went stale when blocks-iam moved).
+* Most Blocks `save`/`update` endpoints are full-record replacements, not patches: a field left out of the body is stored as its default (false, 0, empty), not kept. Every CLI save/update that targets one reads the current record and merges the flags over it (`src/lib/merge-current.ts`); a new such command must first check the server source (the endpoint may be a sparse patch, like `POST /users/{id}` since blocks-iam retired its full-replace body), and must check the GET's field names against the POST DTO because they can differ (`signup-settings` GET says `defaultRolesForNewUser`, POST binds `defaultRolesForNewUserOnSignUp`). Confirm every write by re-reading state after `--yes`.
+* `iam users access grant` replaces a user's whole role list and permission list for one organization when a non-empty list is passed; pass the complete set the user should end up with, and know which `--organization-id` resolves. `iam users update` patches profile fields only -- roles, permissions and MFA state moved to their own endpoints, and the CLI refuses them there.
 * Verify changes before considering the task complete.
 
 ## Working on Blocks apps vs. working on this monorepo
@@ -35,6 +38,8 @@ Two different jobs land here, and the rules below apply only to the second one:
 ## Monorepo-only meta-rules (apply regardless of which job above)
 
 * Never open, read, print, or otherwise expose the CLI's local storage files (its config/token/secret files on disk, wherever `blocks doctor --json` says they live) or anything inside them - client ids, root tenant id, account names, tokens. Only ever interact with them through `blocks` commands.
+
+* Gateway paths are `/<service>/v4/<Controller>/<action>` -- never put `api` after the version segment (`/release/v4/Build/repos-list`, not `/release/v4/api/...`; the gateway answers the latter with an HTML error page). The `/api/...` prefix seen in the portal clients is their same-origin dev-proxy base, not a gateway path. The only legitimate `/api/` URLs in the CLI are the two IdP-host OIDC calls (`oidcUrl` + `/api/oidc/token`, `/api/oidc/device_authorization`), which do not go through the gateway. Check a new path against the service's `server/Api/Controllers` `[Route]`/`[Http*]` attributes; `grep -rn v4/api blocks-cli/src` must stay empty.
 
 ## Documentation Order
 

--- a/blocks-cli/AGENT_GUIDE.md
+++ b/blocks-cli/AGENT_GUIDE.md
@@ -86,7 +86,7 @@ Every field it reports is derived from the command's own source, not from prose,
 
 - Use `blocks ...` for all supported Blocks OS, IAM, Data, Release, and scaffold operations.
 - Prefer `--json` for automation and parsing.
-- Use `--dry-run` before any mutating command.
+- Use `--dry-run` before any mutating command. On `save`/`update` commands the dry-run body is the merged record (current server state with your flags applied), because those endpoints replace the whole document -- read it as "this is exactly what will be stored", and re-read state after `--yes`.
 - Do not run real mutating cloud commands unless the user explicitly approved the exact action.
 - Never print, commit, scaffold, or document access tokens, refresh tokens, cookies, JWTs, or other secrets.
 - Treat any secret pasted into chat or logs as exposed and rotate it before production use.
@@ -331,6 +331,9 @@ Rules:
 
 - Use `--dry-run` before guarded configuration/admin mutations, then `--yes` only after explicit approval. MFA challenge/setup/verify/resend and backup-code consumption are live authentication protocol steps without dry-run; run them only inside the user's explicit authentication flow.
 - Rich payloads (identity provider config, OIDC client config, user/role/permission create-update bodies, etc.) accept `--body '<json>'` or `--file <path.json>` on top of the documented convenience flags - use whichever is easier for the exact fields you need to set.
+- `iam roles update`, `iam signup-settings save`, `iam permissions update`, `auth config save`, `auth oidc-clients save` and `auth client-credentials save --item-id` read the current record first and merge your flags over it, because their endpoints replace the whole document. Omitting a flag keeps the stored value. To clear a boolean, pass it explicitly (`--is-default=false`); to clear a text field, use `--body '{"description": ""}'` -- an empty convenience flag reads as "not passed" and keeps the stored value.
+- `iam users update` is a sparse patch (the server keeps omitted/null fields itself, `""` via `--body` clears one), so it sends only the fields you pass and needs no read. Roles, permissions and MFA state are not part of this endpoint any more -- the CLI rejects them with a pointer to `iam users access grant` and the MFA commands.
+- `iam users access grant`: a non-empty `--roles` or `--permissions` REPLACES that organization's list (an omitted one is kept). The dry-run prints `current` so you can see what a grant would drop; pass the complete set.
 - `auth idp create`/`update`, `auth client-credentials save`, and `auth oidc-clients save`/`rotate-secret` can return a `client_secret` shown only once. Never print, log, commit, or otherwise persist it outside what the user explicitly asked to store; treat that response the same as any other CLI-managed secret.
 - Do not add IAM/MFA/Auth admin behavior outside these supported CLI commands unless the CLI package is explicitly extended and tested.
 
@@ -650,7 +653,7 @@ For a repo that has never been deployed, use `release setup` instead - it calls 
 
 If no repo is linked yet, the commands fail with `repo_not_linked` - that requires GitHub OAuth, so it can only be done from the Blocks portal; do not attempt to link a repo from the CLI.
 
-`--wait` polls `/release/v4/api/Build` every `--poll-interval` seconds (default 10) and reads the build's status FIELD against the server's terminal vocabulary (Succeeded/Failed/Cancelled/Timeout/...), until terminal or `--timeout` elapses (default 900s). All progress goes to stderr; with `--json`, stdout is exactly one `{buildId, status, verdict, build}` document, where `verdict` is a stable `succeeded`/`failed`/`running`. `--follow` implies `--wait` and streams pipeline events to stderr as they appear. Without either, `release deploy` returns immediately with just a build id.
+`--wait` polls `/release/v4/Build` every `--poll-interval` seconds (default 10) and reads the build's status FIELD against the server's terminal vocabulary (Succeeded/Failed/Cancelled/Timeout/...), until terminal or `--timeout` elapses (default 900s). All progress goes to stderr; with `--json`, stdout is exactly one `{buildId, status, verdict, build}` document, where `verdict` is a stable `succeeded`/`failed`/`running`. `--follow` implies `--wait` and streams pipeline events to stderr as they appear. Without either, `release deploy` returns immediately with just a build id.
 
 Read builds and logs:
 

--- a/blocks-cli/CHANGELOG.md
+++ b/blocks-cli/CHANGELOG.md
@@ -6,6 +6,94 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Versions before 0.3.0 were released without a changelog; their history is in the
 repository's git log.
 
+## 0.4.1
+
+### Fixed
+
+- Ten save/update commands no longer wipe the fields they were not asked
+  to change. Their endpoints replace the whole stored document from the
+  request DTO, so an omitted field arrived as the C# default (false, 0, "",
+  empty list) and overwrote what was there. Each command now reads the
+  current record and merges the flags over it, the way `iam permissions
+  update`, `auth config save` and `auth oidc-clients save` already did
+  (shared helper: `src/lib/merge-current.ts`). Omitting a flag keeps the
+  stored value; pass it explicitly to clear it.
+  - `iam signup-settings save`: `--default-roles participant` alone turned
+    `isEmailPasswordSignUpEnabled` off and emptied the default permissions.
+    The GET spells the lists `defaultRolesForNewUser`/`...Permissions...`
+    while the POST binds `...OnSignUp`, so the merge renames them.
+  - `iam roles update`: a rename cleared the description, detached the
+    parent role and turned `canCreateOwn` off.
+  - `auth client-credentials save --item-id`: a roles-only save re-activated
+    a disabled credential, reset the token lifetime to 5 minutes and dropped
+    every permission. The secret is never carried.
+  - `data config update`: a connection-string-only update reset
+    `isCollectionNameEditable` and `collectionNamePattern`.
+  - `localization key save`: `--value` replaced every translation with the
+    one culture passed, and a save without `--value` dropped them all. It now
+    upserts that culture's entry and keeps the rest; `--culture` is required
+    with `--value`.
+  - `localization glossary save --item-id`: dropped language, type, context,
+    note, `isGlobal` and module tags.
+  - `localization language save`: re-saving the default language without
+    `--is-default` demoted it. The name is matched exactly (case included),
+    like the server's own lookup -- a differently-cased name is a create, and
+    must not inherit this record's `isDefault`.
+  - `mail config save --configuration-id`: a host-only update turned SSL off,
+    flipped inbound to outbound, reset the provider and dropped
+    `isEnableSnsConfiguration`. `--account-password` is still required on
+    update (the server insists, and returns it masked).
+  - `notification save`: changing one of channel/type/persistence reset the
+    other two. When the name already exists the CLI also sets
+    `isUpdateRequest: true` automatically -- without it the server rejects
+    every update as a duplicate name. Name matching is exact (case included),
+    like the server's own lookup.
+  - `captcha save <id>`: rotating the secret disabled the configuration and
+    blanked its site key. `--provider` is now only required on create.
+- Every `release` command hit `/release/v4/api/...` and got the gateway's HTML
+  error page back ("Blocks API returned HTML for /release/v4/api/Build/repos-list").
+  blocks-release routes are `[Route("[controller]")]` with no `api` segment, like
+  every other service behind the gateway; the base is now `/release/v4`. The
+  portal's `/api` prefix is its own dev-proxy base, not a gateway path.
+- `blocks logout` posted to `/iam/v4/api/auth/logout` for the same reason; it
+  now uses `/iam/v4/auth/logout`, matching the impersonate/stop calls beside it.
+- `storage config delete` sent `DELETE`, but blocks-os declares Storage/Delete
+  as a POST (unlike Mail/Delete and Notification/Delete, which are DELETEs), so
+  every delete got 405. Found in a sweep of all 180+ CLI endpoints against the
+  service controllers; this was the only remaining route/verb mismatch. Known
+  server-side quirk from the same sweep, not fixable client-side: `notifier
+  unread`'s filter is declared body-bound on a GET, so the CLI's query-string
+  flattening is not honored until blocks-logic reads it from the query.
+- `iam users access grant` dry-run and confirmation now show the
+  organization's current roles and permissions. The endpoint keeps a list
+  you omit (for an existing member; a first grant into a new organization
+  starts the omitted list empty) but REPLACES one you pass, so `--roles
+  editor` on an admin left them with editor only -- that is now visible
+  before `--yes`.
+- `iam users update` matches what blocks-iam ships today: `POST /users/{id}`
+  is a sparse patch (omitted/null keeps the stored value, `""` via `--body`
+  clears it), so the CLI sends only the fields you pass and no longer needs a
+  read. Roles, permissions, `mfaEnabled` and `userMfaType` were retired from
+  this endpoint -- the server ignores them with only a log line -- so the CLI
+  now rejects them with a typed error pointing at `iam users access grant`
+  and the MFA commands instead of letting the change silently not happen.
+
+### Added
+
+- `npm run verify:endpoints` (`scripts/verify-endpoints.mjs`): checks every
+  route+verb the CLI sends against the ASP.NET controllers in the checked-out
+  sibling service repos, so a moved route or changed verb fails mechanically
+  instead of surfacing as a live 404/405. Route+verb only -- DTO shapes and
+  replace-vs-patch semantics still need the server source read.
+
+### Changed
+
+- The dry-run of a merging save/update command performs the read it merges
+  from, so it needs a selected project and network access; create-path
+  dry-runs (no id) stay offline as before, and so does `iam users update`
+  (a sparse patch needs no read).
+- `iam users update` no longer accepts `--roles`/`--permissions` (see Fixed).
+
 ## 0.4.0
 
 ### Added

--- a/blocks-cli/command-docs.json
+++ b/blocks-cli/command-docs.json
@@ -65,7 +65,7 @@
     "details": "Requires --email or --user-name; omit --password to let the user set their own via activation mail."
   },
   "iam users update": {
-    "summary": "Update an existing IAM user's profile fields, roles, or permissions.",
+    "summary": "Update an existing IAM user's profile fields (sparse patch: omitted fields are kept). Roles/permissions/MFA belong to 'iam users access grant' and the MFA commands.",
     "positional": "<id>"
   },
   "iam users activate": {

--- a/blocks-cli/package.json
+++ b/blocks-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seliseblocks/cli-os",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI for SELISE Blocks project setup and configuration.",
   "keywords": [
     "selise",
@@ -51,6 +51,7 @@
     "build": "npm run clean && tsc -p tsconfig.json",
     "dev": "tsx src/index.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
+    "verify:endpoints": "node scripts/verify-endpoints.mjs",
     "test": "npm run build && node --test test/*.test.mjs",
     "prepack": "npm run build",
     "prepublishOnly": "npm test"

--- a/blocks-cli/scripts/verify-endpoints.mjs
+++ b/blocks-cli/scripts/verify-endpoints.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Endpoint sweep: every route+verb the CLI sends, checked against the actual
+// ASP.NET controllers in the sibling service repos (blocks-iam, blocks-os,
+// blocks-data, blocks-localization, blocks-logic, blocks-release).
+//
+// Motivation: the 0.4.x releases fixed two whole classes of bug this check
+// would have caught mechanically -- every `release` command 404ing on a stale
+// `/api` base segment, and `storage config delete` sending DELETE at an
+// endpoint the server declares as POST. Skill prose and CHANGELOG claims are
+// written from the server source; when the server moves, this is the tripwire.
+//
+// Scope: route template + HTTP verb only. Binding (FromQuery vs FromBody),
+// DTO field names and replace-vs-patch semantics still need a human read of
+// the service -- see AGENTS.md.
+//
+// Service repos are looked up as siblings of this git repo's parent
+// (../../blocks-iam etc.). A missing repo is reported and skipped, so this
+// stays runnable from a CLI-only checkout; it only FAILS on a real mismatch
+// against a repo that is present. Run: npm run verify:endpoints
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const cliRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const servicesRoot = join(cliRoot, "..", "..");
+
+const SERVICES = {
+  data: "blocks-data",
+  iam: "blocks-iam",
+  localization: "blocks-localization",
+  logic: "blocks-logic",
+  os: "blocks-os",
+  release: "blocks-release"
+};
+
+// Constants the CLI builds paths from; kept in sync with the source of each.
+const PATH_CONSTANTS = {
+  "${LOCALIZATION_API}": "/localization/v4",
+  "${OS_CAPTCHA_API}": "/os/v4/captcha",
+  "${OS_SECRETS_API}": "/os/v4/Secrets",
+  "${RELEASE_API}": "/release/v4"
+};
+
+// ---------------------------------------------------------------- CLI side --
+function* walk(dir, filter) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (["obj", "bin", "node_modules", "dist"].includes(entry.name)) continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(path, filter);
+    else if (filter(path)) yield path;
+  }
+}
+
+/** Reads the balanced argument list of one blocksRequest(...) call, string-aware. */
+function callText(source, openParen) {
+  let depth = 0;
+  let quote = null;
+  for (let i = openParen; i < source.length; i += 1) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === "\\") i += 1;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") quote = ch;
+    else if (ch === "(") depth += 1;
+    else if (ch === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openParen, i + 1);
+    }
+  }
+  return source.slice(openParen);
+}
+
+function normalizePath(raw) {
+  let path = raw;
+  for (const [name, value] of Object.entries(PATH_CONSTANTS)) path = path.replaceAll(name, value);
+  // Any interpolated segment matches one path segment server-side.
+  path = path.replace(/\$\{[^}]*\}/g, "{p}");
+  return path;
+}
+
+function verbOf(options) {
+  const literal = options.match(/method:\s*"(\w+)"/);
+  if (literal) return literal[1].toUpperCase();
+  if (/method\s*[:\]]/.test(options)) return "ANY"; // conditional method -- check path only
+  return /\bbody\s*[:,}]/.test(options) ? "POST" : "GET";
+}
+
+function collectCliCalls() {
+  const calls = new Map(); // "VERB path" -> [files]
+  for (const file of walk(join(cliRoot, "src"), (p) => p.endsWith(".ts"))) {
+    const source = readFileSync(file, "utf8");
+    const re = /blocksRequest(?:<[^>]*>)?\(\s*(`[^`]*`|"[^"]*")/g;
+    let m;
+    while ((m = re.exec(source))) {
+      const path = normalizePath(m[1].slice(1, -1));
+      if (!path.startsWith("/")) continue;
+      const options = callText(source, source.indexOf("(", m.index));
+      const key = `${verbOf(options)} ${path}`;
+      if (!calls.has(key)) calls.set(key, []);
+      calls.get(key).push(file.slice(cliRoot.length + 1).replaceAll("\\", "/"));
+    }
+    // Session-plumbing calls in lib/auth.ts use fetch(new URL(...)) directly.
+    for (const raw of source.matchAll(/new URL\(\s*"(\/[a-z]+\/v4\/[^"]+)"/g)) {
+      const key = `ANY ${normalizePath(raw[1])}`;
+      if (!calls.has(key)) calls.set(key, []);
+      calls.get(key).push(file.slice(cliRoot.length + 1).replaceAll("\\", "/"));
+    }
+  }
+  return calls;
+}
+
+// ------------------------------------------------------------- server side --
+function collectServerRoutes(repoDir) {
+  const routes = []; // { verb, segments: ["Mail","Save"] }
+  const controllersRoot = join(repoDir, "server");
+  if (!existsSync(controllersRoot)) return null;
+  for (const file of walk(controllersRoot, (p) => p.endsWith(".cs") && p.replaceAll("\\", "/").includes("/Controllers/"))) {
+    const source = readFileSync(file, "utf8");
+    // Handles primary constructors ("class XController(IFoo foo) : ControllerBase") too.
+    const cls = source.match(/class\s+(\w+?)(?:Controller)?\s*[(:]/);
+    const routeAttr = source.match(/\[Route\("([^"]*)"\)\]/);
+    if (!cls || !routeAttr) continue;
+    const base = routeAttr[1].replace("[controller]", cls[1]);
+    // Each [HttpX] attribute is tied to the next public method BY POSITION rather than by
+    // one attributes-then-method regex: comments and arbitrary attributes may sit between
+    // them (MailController has a commented-out [ProtectedEndPoint] mid-block), and one
+    // action may declare several [HttpX] routes (Key/DeleteKeys is POST and DELETE).
+    const methods = [...source.matchAll(/public\s+(?:async\s+)?[\w<>?,.[\] ]+?\s+(\w+)\s*\(/g)];
+    for (const attr of source.matchAll(/\[Http(Get|Post|Put|Delete|Patch)(?:\("([^"]*)"\))?\]/g)) {
+      const method = methods.find((candidate) => candidate.index > attr.index);
+      if (!method) continue;
+      const [, verb, template] = attr;
+      let path = base.replace("[action]", method[1]);
+      if (template) path = `${path}/${template}`;
+      routes.push({ verb: verb.toUpperCase(), segments: path.split("/").filter(Boolean) });
+    }
+  }
+  return routes;
+}
+
+function matches(route, verb, segments) {
+  if (verb !== "ANY" && route.verb !== verb) return false;
+  if (route.segments.length !== segments.length) return false;
+  return segments.every((segment, i) => {
+    const server = route.segments[i];
+    if (segment.startsWith("{") || server.startsWith("{")) return true;
+    return server.toLowerCase() === segment.toLowerCase();
+  });
+}
+
+// -------------------------------------------------------------------- main --
+const serverRoutes = {};
+const missingRepos = [];
+for (const [service, repo] of Object.entries(SERVICES)) {
+  const routes = collectServerRoutes(join(servicesRoot, repo));
+  if (routes === null) missingRepos.push(repo);
+  else serverRoutes[service] = routes;
+}
+
+const failures = [];
+let checked = 0;
+let skipped = 0;
+for (const [key, files] of [...collectCliCalls()].sort()) {
+  const [verb, path] = key.split(" ");
+  const [, service, version, ...rest] = path.split("/");
+  if (version !== "v4") continue;
+  const routes = serverRoutes[service];
+  if (!routes) { skipped += 1; continue; }
+  checked += 1;
+  if (!routes.some((route) => matches(route, verb, rest))) {
+    failures.push(`${verb} ${path}\n    called from: ${[...new Set(files)].join(", ")}`);
+  }
+}
+
+if (missingRepos.length > 0) console.log(`skipped repos (not checked out): ${missingRepos.join(", ")}${skipped ? ` -- ${skipped} calls unverified` : ""}`);
+if (failures.length > 0) {
+  console.error(`MISMATCH: ${failures.length} CLI call(s) have no matching controller route+verb:\n  ${failures.join("\n  ")}`);
+  process.exit(1);
+}
+console.log(`ok: ${checked} CLI route+verb pairs match a controller route in the checked-out service repos`);

--- a/blocks-cli/src/commands/auth/client-credentials/save.ts
+++ b/blocks-cli/src/commands/auth/client-credentials/save.ts
@@ -2,6 +2,7 @@ import { booleanFlag, optionalBooleanFlag, optionalIntegerFlag, stringFlag } fro
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag, listFlag } from "../../../lib/json-flag.js";
+import { carryCurrent, findInList } from "../../../lib/merge-current.js";
 import { redactSecrets } from "../../../lib/redact.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
@@ -9,7 +10,7 @@ import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 
 export async function authClientCredentialsSave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
-  const body = {
+  const overrides = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       accessTokenValidForNumberMinutes: optionalIntegerFlag(flags, "access-token-valid-minutes"),
@@ -21,7 +22,33 @@ export async function authClientCredentialsSave(argv: string[]): Promise<void> {
     })
   };
 
-  if (!body.name && !body.itemId) throw new Error("Provide --name (create) or --item-id (update), or set them in --body/--file.");
+  if (!overrides.name && !overrides.itemId) throw new Error("Provide --name (create) or --item-id (update), or set them in --body/--file.");
+
+  const itemId = typeof overrides.itemId === "string" ? overrides.itemId : undefined;
+
+  // Saving with an itemId replaces the credential: the service copies Name, IsActive,
+  // AccessTokenValidForNumberMinutes, Roles and Permissions from the request as-is, and
+  // the request DTO defaults IsActive to true, the lifetime to 5 minutes and both lists
+  // to empty. A roles-only save therefore re-activated a disabled credential, reset its
+  // token lifetime and dropped every permission. There is no GET-by-id, so the current
+  // record comes from the list. ClientSecret is deliberately not carried -- the save
+  // DTO has no such field, and the secret must never be echoed back at the API. A new
+  // credential has nothing to read, so its dry-run stays offline.
+  const current = itemId
+    ? carryCurrent(
+        findClientCredential(
+          await blocksRequest<unknown>("/iam/v4/auth/client-credentials", {
+            impersonatedProjectAuth: true,
+            ...requestContext(flags),
+            projectTenantId: await selectedProject(flags)
+          }),
+          itemId
+        ),
+        ["name", "isActive", "accessTokenValidForNumberMinutes", "roles", "permissions"]
+      )
+    : {};
+
+  const body = { ...current, ...overrides };
 
   if (booleanFlag(flags, "dry-run")) {
     writeOutput({ dryRun: true, endpoint: "/iam/v4/auth/client-credentials", request: redactSecrets(body) }, flags);
@@ -37,4 +64,10 @@ export async function authClientCredentialsSave(argv: string[]): Promise<void> {
     projectTenantId: projectKey
   });
   writeOutput(result, flags);
+}
+
+function findClientCredential(list: unknown, itemId: string): Record<string, unknown> {
+  const found = findInList(list, (item) => item.itemId === itemId);
+  if (!found) throw new Error(`Client credential '${itemId}' was not found. Run 'blocks auth client-credentials list --json' for the current ids.`);
+  return found;
 }

--- a/blocks-cli/src/commands/captcha/save.ts
+++ b/blocks-cli/src/commands/captcha/save.ts
@@ -1,27 +1,22 @@
 import { booleanFlag, optionalBooleanFlag, stringFlag } from "../../lib/args.js";
 import { blocksRequest } from "../../lib/api.js";
-import { CAPTCHA_PROVIDERS, CaptchaConfig, OS_CAPTCHA_API, captchaSummary } from "../../lib/captcha.js";
+import { CAPTCHA_PROVIDERS, CaptchaConfig, OS_CAPTCHA_API, captchaSummary, getCaptchaConfig } from "../../lib/captcha.js";
 import { confirmMutation } from "../../lib/confirm.js";
 import { CliActionableError } from "../../lib/errors.js";
 import { compact, jsonBodyFlag } from "../../lib/json-flag.js";
+import { carryCurrent } from "../../lib/merge-current.js";
 import { writeOutput } from "../../lib/output.js";
 import { redactSecrets } from "../../lib/redact.js";
 import { requestContext } from "../../lib/request-context.js";
 import { requireOneOf } from "../../lib/secrets.js";
 import { parseCommand, selectedProject } from "../../lib/workspace.js";
 
-/**
- * Create or update a captcha configuration (captcha/save). Omit --id to create; pass it
- * to update. The server stores the captcha secret in the Secrets store: on create a
- * non-empty --captcha-secret creates that secret, on update it ROTATES the linked one,
- * and an omitted/empty --captcha-secret leaves the stored value untouched.
- */
 export async function captchaSave(argv: string[]): Promise<void> {
   const { args, flags } = parseCommand(argv);
   const provider = stringFlag(flags, "provider");
   if (provider) requireOneOf(provider, CAPTCHA_PROVIDERS, "provider", "invalid_captcha_provider");
 
-  const body: Record<string, unknown> = {
+  const overrides: Record<string, unknown> = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       captchaGenerator: stringFlag(flags, "generator") || undefined,
@@ -33,7 +28,22 @@ export async function captchaSave(argv: string[]): Promise<void> {
     })
   };
 
-  const isUpdate = typeof body.id === "string" && body.id.length > 0;
+  const isUpdate = typeof overrides.id === "string" && overrides.id.length > 0;
+
+  // The save endpoint rebuilds the stored record from the request -- IsEnable, Provider,
+  // CaptchaKey and CaptchaGenerator -- and only the linked secret is preserved when
+  // captchaSecret is left empty. An update that merely rotated the secret therefore
+  // switched the configuration off and blanked its site key. Read the record first and
+  // merge, the same way `captcha enable`/`disable` already re-save it; a new
+  // configuration has nothing to carry, so its dry-run stays offline.
+  const current = isUpdate
+    ? carryCurrent(
+        await getCaptchaConfig(overrides.id as string, await selectedProject(flags), flags),
+        ["isEnable", "provider", "captchaKey", "captchaGenerator"]
+      )
+    : {};
+  const body: Record<string, unknown> = { ...current, ...overrides };
+
   if (!body.provider) {
     throw new CliActionableError(
       "--provider is required (the server rejects an empty provider).",

--- a/blocks-cli/src/commands/data/config/update.ts
+++ b/blocks-cli/src/commands/data/config/update.ts
@@ -2,6 +2,7 @@ import { booleanFlag, optionalBooleanFlag, stringFlag } from "../../../lib/args.
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag } from "../../../lib/json-flag.js";
+import { carryCurrent } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { redactSecrets } from "../../../lib/redact.js";
 import { requestContext } from "../../../lib/request-context.js";
@@ -10,7 +11,26 @@ import { withGatewayReload } from "../../../lib/data-gateway.js";
 
 export async function dataConfigUpdate(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
+  const projectKey = await selectedProject(flags);
+
+  // PUT /configurations rebinds the whole data source. ConnectionString and
+  // DatabaseName are validated as required, so omitting them fails loudly -- but
+  // IsCollectionNameEditable is a non-nullable bool and CollectionNamePattern defaults
+  // to "", so a connection-string-only update silently reset both. Read the current
+  // configuration (the GET returns the connection string decoded, under
+  // `dbConnectionString`) and merge the flags over it.
+  const current = carryCurrent(
+    await blocksRequest<unknown>("/data/v4/configurations", {
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId: projectKey
+    }),
+    ["itemId", "dbConnectionString", "databaseName", "isCollectionNameEditable", "collectionNamePattern"],
+    { dbConnectionString: "connectionString" }
+  );
+
   const body = {
+    ...current,
     ...(await jsonBodyFlag(flags)),
     ...compact({
       collectionNamePattern: stringFlag(flags, "collection-name-pattern") || undefined,
@@ -29,7 +49,6 @@ export async function dataConfigUpdate(argv: string[]): Promise<void> {
   }
 
   await confirmMutation(flags, `Update data source configuration '${body.itemId}'.`);
-  const projectKey = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/data/v4/configurations", {
     body: { ...body, projectKey },
     impersonatedProjectAuth: true,

--- a/blocks-cli/src/commands/iam/roles/update.ts
+++ b/blocks-cli/src/commands/iam/roles/update.ts
@@ -2,6 +2,7 @@ import { booleanFlag, optionalBooleanFlag, stringFlag } from "../../../lib/args.
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag } from "../../../lib/json-flag.js";
+import { carryCurrent } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
@@ -9,7 +10,25 @@ import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 export async function iamRolesUpdate(argv: string[]): Promise<void> {
   const { args, flags } = parseCommand(argv);
   const itemId = args[0] || stringFlag(flags, "item-id", { required: true });
+  const projectKey = await selectedProject(flags);
+
+  // POST /roles/update assigns Description and ParentRoleSlug straight from the request
+  // (null when omitted) and CanCreateOwn is a non-nullable bool, so a rename used to
+  // clear the description, detach the role from its parent and turn CanCreateOwn off.
+  // Name is validated as required, which is the one field that never wiped silently.
+  // Read the role and merge. PropagateToOtherOrg describes this call, not the role, so
+  // it is deliberately not carried.
+  const current = carryCurrent(
+    await blocksRequest<unknown>(`/iam/v4/iam/roles/${encodeURIComponent(itemId)}`, {
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId: projectKey
+    }),
+    ["name", "description", "parentRoleSlug", "canCreateOwn"]
+  );
+
   const body = {
+    ...current,
     ...(await jsonBodyFlag(flags)),
     ...compact({
       canCreateOwn: optionalBooleanFlag(flags, "can-create-own"),
@@ -27,7 +46,6 @@ export async function iamRolesUpdate(argv: string[]): Promise<void> {
   }
 
   await confirmMutation(flags, `Update IAM role '${itemId}'.`);
-  const projectKey = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/iam/v4/iam/roles/update", {
     body,
     impersonatedProjectAuth: true,

--- a/blocks-cli/src/commands/iam/signup-settings/save.ts
+++ b/blocks-cli/src/commands/iam/signup-settings/save.ts
@@ -2,13 +2,37 @@ import { booleanFlag, optionalBooleanFlag } from "../../../lib/args.js";
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag, listFlag } from "../../../lib/json-flag.js";
+import { carryCurrent } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 
 export async function iamSignupSettingsSave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
+  const projectKey = await selectedProject(flags);
+
+  // POST /signup-settings is a full replace: SaveSignUpSettingRequest declares both
+  // booleans non-nullable and both lists default to empty, and the service assigns all
+  // four onto the tenant configuration unconditionally. `--default-roles participant`
+  // on its own therefore switched public signup off and emptied the default
+  // permissions. Read the current settings first and merge the flags over them. The
+  // GET spells the list fields without the `OnSignUp` suffix the POST binds, so a
+  // plain spread would carry nothing for them -- hence the rename.
+  const current = carryCurrent(
+    await blocksRequest<unknown>("/iam/v4/iam/signup-settings", {
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId: projectKey
+    }),
+    ["isEmailPasswordSignUpEnabled", "isSSoSignUpEnabled", "defaultRolesForNewUser", "defaultPermissionsForNewUser"],
+    {
+      defaultPermissionsForNewUser: "defaultPermissionsForNewUserOnSignUp",
+      defaultRolesForNewUser: "defaultRolesForNewUserOnSignUp"
+    }
+  );
+
   const body = {
+    ...current,
     ...(await jsonBodyFlag(flags)),
     ...compact({
       defaultPermissionsForNewUserOnSignUp: listFlag(flags, "default-permissions"),
@@ -24,7 +48,6 @@ export async function iamSignupSettingsSave(argv: string[]): Promise<void> {
   }
 
   await confirmMutation(flags, "Save IAM signup settings for the selected project.");
-  const projectKey = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/iam/v4/iam/signup-settings", {
     body,
     impersonatedProjectAuth: true,

--- a/blocks-cli/src/commands/iam/users/access-grant.ts
+++ b/blocks-cli/src/commands/iam/users/access-grant.ts
@@ -2,6 +2,7 @@ import { booleanFlag, stringFlag } from "../../../lib/args.js";
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { listFlag } from "../../../lib/json-flag.js";
+import { carryCurrent } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
@@ -9,22 +10,57 @@ import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 export async function iamUsersAccessGrant(argv: string[]): Promise<void> {
   const { args, flags } = parseCommand(argv);
   const userId = args[0] || stringFlag(flags, "user-id", { required: true });
+  const addPermissions = listFlag(flags, "permissions");
+  const roles = listFlag(flags, "roles");
+  const organizationId = stringFlag(flags, "organization-id") || undefined;
   const body = {
-    organizationId: stringFlag(flags, "organization-id") || undefined,
-    permissions: listFlag(flags, "permissions"),
-    roles: listFlag(flags, "roles"),
+    organizationId,
+    permissions: addPermissions,
+    roles,
     userId
   };
 
   if (!body.roles && !body.permissions) throw new Error("Provide --roles and/or --permissions to grant.");
 
+  const projectKey = await selectedProject(flags);
+
+  // /users/access keeps the stored list when one is omitted or empty, but a non-empty
+  // --roles or --permissions REPLACES that organization's whole list rather than adding
+  // to it -- `--roles editor` on a user who is also `admin` leaves them with editor only.
+  // Read the current lists (the GET flattens them for the same organization the grant
+  // resolves) so a grant that would drop something is visible before it is confirmed.
+  const current = carryCurrent(
+    await blocksRequest<unknown>(`/iam/v4/iam/users/${encodeURIComponent(userId)}`, {
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId: projectKey,
+      query: { organizationId }
+    }),
+    ["roles", "permissions"]
+  );
+  const currentRoles = Array.isArray(current.roles) ? current.roles : [];
+  const currentPermissions = Array.isArray(current.permissions) ? current.permissions : [];
+
   if (booleanFlag(flags, "dry-run")) {
-    writeOutput({ dryRun: true, endpoint: "/iam/v4/iam/users/access", request: body }, flags);
+    writeOutput(
+      {
+        current: { permissions: currentPermissions, roles: currentRoles },
+        dryRun: true,
+        endpoint: "/iam/v4/iam/users/access",
+        replaces:
+          "a non-empty roles/permissions list replaces the organization's current list; an omitted one is kept for an existing member and starts empty when this grant first adds the organization",
+        request: body
+      },
+      flags
+    );
     return;
   }
 
-  await confirmMutation(flags, `Grant access to IAM user '${userId}'.`);
-  const projectKey = await selectedProject(flags);
+  const summary = [
+    roles ? `roles ${JSON.stringify(currentRoles)} -> ${JSON.stringify(roles)}` : undefined,
+    addPermissions ? `permissions ${JSON.stringify(currentPermissions)} -> ${JSON.stringify(addPermissions)}` : undefined
+  ].filter(Boolean).join("; ");
+  await confirmMutation(flags, `Set access for IAM user '${userId}' (replaces the listed sets): ${summary}.`);
   const result = await blocksRequest<unknown>("/iam/v4/iam/users/access", {
     body,
     impersonatedProjectAuth: true,

--- a/blocks-cli/src/commands/iam/users/update.ts
+++ b/blocks-cli/src/commands/iam/users/update.ts
@@ -1,28 +1,60 @@
 import { booleanFlag, stringFlag } from "../../../lib/args.js";
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
-import { compact, jsonBodyFlag, listFlag } from "../../../lib/json-flag.js";
+import { CliActionableError } from "../../../lib/errors.js";
+import { compact, jsonBodyFlag } from "../../../lib/json-flag.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 
+// Roles, permissions and MFA state left POST /users/{id} for the endpoints that own
+// them. The server binds them into UnmappedFields, logs a warning and returns 200
+// having changed nothing -- so the CLI refuses them up front instead of letting a
+// grant silently not happen. (ItemId/OrganizationId still bind; only these four are
+// dead in a body.)
+const RETIRED_UPDATE_FIELDS = ["roles", "permissions", "mfaEnabled", "userMfaType"];
+
 export async function iamUsersUpdate(argv: string[]): Promise<void> {
   const { args, flags } = parseCommand(argv);
   const id = args[0] || stringFlag(flags, "id", { required: true });
+
+  for (const flag of ["roles", "permissions"]) {
+    if (flag in flags) {
+      throw new CliActionableError(
+        `--${flag} is no longer part of 'iam users update': the endpoint patches profile fields only and ignores it.`,
+        "retired_update_field",
+        `Use 'blocks iam users access grant ${id} --${flag} ...' instead -- note a non-empty list REPLACES that organization's list.`
+      );
+    }
+  }
+
+  // POST /users/{id} is a sparse patch: UpdateUserRequest binds every profile field as
+  // nullable with no initializer, and the service applies only the non-null ones
+  // (absent or null keeps the stored value, "" clears it). Send exactly the fields
+  // being changed -- no read-and-merge round-trip, and the dry-run stays offline.
+  // Clearing a text field therefore goes through --body ('{"lastName": ""}'), because
+  // an empty convenience flag reads as "not passed".
   const body = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
-      // IAM validates ItemId from the BODY, not the path segment, and rejects the
-      // whole request without it -- every update failed with a bare 400 otherwise.
+      // The route sets ItemId server-side; carried in the body too so the dry-run and
+      // confirmation show the exact record being written.
       itemId: id,
       firstName: stringFlag(flags, "first-name") || undefined,
       lastName: stringFlag(flags, "last-name") || undefined,
       organizationId: stringFlag(flags, "organization-id") || undefined,
-      permissions: listFlag(flags, "permissions"),
-      phoneNumber: stringFlag(flags, "phone-number") || undefined,
-      roles: listFlag(flags, "roles")
+      phoneNumber: stringFlag(flags, "phone-number") || undefined
     })
   };
+
+  const retired = RETIRED_UPDATE_FIELDS.filter((field) => field in body);
+  if (retired.length > 0) {
+    throw new CliActionableError(
+      `The update-user endpoint ignores ${retired.join(", ")} -- it patches profile fields only, and the server would return 200 without applying them.`,
+      "retired_update_field",
+      `Move roles/permissions to 'blocks iam users access grant ${id}' and MFA state to the MFA commands, then re-run without them.`
+    );
+  }
 
   if (booleanFlag(flags, "dry-run")) {
     writeOutput({ dryRun: true, endpoint: `/iam/v4/iam/users/${encodeURIComponent(id)}`, request: body }, flags);

--- a/blocks-cli/src/commands/localization/glossary/save.ts
+++ b/blocks-cli/src/commands/localization/glossary/save.ts
@@ -2,13 +2,14 @@ import { booleanFlag, optionalBooleanFlag, stringFlag } from "../../../lib/args.
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag, listFlag } from "../../../lib/json-flag.js";
+import { carryCurrent } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 
 export async function localizationGlossarySave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
-  const body = {
+  const overrides = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       additionalNote: stringFlag(flags, "additional-note") || undefined,
@@ -22,6 +23,27 @@ export async function localizationGlossarySave(argv: string[]): Promise<void> {
     })
   };
 
+  const projectTenantId = await selectedProject(flags);
+  const itemId = typeof overrides.itemId === "string" ? overrides.itemId : undefined;
+
+  // Glossary/Save with an itemId rebuilds the stored term from the request: only
+  // ItemId and CreateDate are kept from the existing document, and Language, Type,
+  // Context, AdditionalNote, IsGlobal and ModuleIds are assigned exactly as sent (null
+  // or false when omitted). Read the term first when updating and merge; a new term
+  // has nothing to carry.
+  const current = itemId
+    ? carryCurrent(
+        await blocksRequest<unknown>("/localization/v4/Glossary/Get", {
+          impersonatedProjectAuth: true,
+          ...requestContext(flags),
+          projectTenantId,
+          query: { itemId }
+        }),
+        ["name", "language", "type", "context", "additionalNote", "isGlobal", "moduleIds"]
+      )
+    : {};
+
+  const body = { ...current, ...overrides };
   if (!body.name) throw new Error("Provide --name (or set it in --body/--file).");
 
   if (booleanFlag(flags, "dry-run")) {
@@ -30,7 +52,6 @@ export async function localizationGlossarySave(argv: string[]): Promise<void> {
   }
 
   await confirmMutation(flags, `Save glossary term '${body.name}'.`);
-  const projectTenantId = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/localization/v4/Glossary/Save", {
     body,
     impersonatedProjectAuth: true,

--- a/blocks-cli/src/commands/localization/key/save.ts
+++ b/blocks-cli/src/commands/localization/key/save.ts
@@ -1,7 +1,9 @@
 import { booleanFlag, optionalBooleanFlag, stringFlag } from "../../../lib/args.js";
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
+import { isRecord } from "../../../lib/data-response.js";
 import { compact, jsonBodyFlag, listFlag } from "../../../lib/json-flag.js";
+import { carryCurrent, findInList, sameName } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
@@ -10,7 +12,9 @@ export async function localizationKeySave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
   const value = stringFlag(flags, "value") || undefined;
   const culture = stringFlag(flags, "culture") || undefined;
-  const body = {
+  if (value && !culture) throw new Error("Pass --culture with --value: a translation is stored per culture.");
+
+  const overrides = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       context: stringFlag(flags, "context") || undefined,
@@ -20,14 +24,36 @@ export async function localizationKeySave(argv: string[]): Promise<void> {
       itemId: stringFlag(flags, "item-id") || undefined,
       keyName: stringFlag(flags, "key-name") || undefined,
       moduleId: stringFlag(flags, "module-id") || undefined,
-      resources: value ? [{ characterLength: value.length, culture, value }] : undefined,
       routes: listFlag(flags, "routes"),
       shouldPublish: optionalBooleanFlag(flags, "should-publish")
     })
   };
 
-  if (!body.keyName) throw new Error("Provide --key-name (or set it in --body/--file).");
-  if (!body.moduleId) throw new Error("Provide --module-id (or set it in --body/--file).");
+  if (!overrides.keyName) throw new Error("Provide --key-name (or set it in --body/--file).");
+  if (!overrides.moduleId) throw new Error("Provide --module-id (or set it in --body/--file).");
+
+  const projectTenantId = await selectedProject(flags);
+
+  // Key/Save upserts by keyName + moduleId and then assigns Resources, Routes,
+  // GlossaryIds, Context and IsPartiallyTranslated from the request as-is. Resources is
+  // the list of translations, one entry per culture -- so `--value` used to replace
+  // every translation with the single culture passed, and a save without `--value`
+  // dropped all of them. Read the existing key and merge: `--value` upserts one
+  // culture's entry and leaves the others alone, while an explicit `resources` in
+  // --body/--file still replaces the whole list.
+  const existing = findInList(
+    await blocksRequest<unknown>("/localization/v4/Key/GetsByKeyNames", {
+      body: { keyNames: [overrides.keyName], moduleId: overrides.moduleId },
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId
+    }),
+    (item) => sameName(item.keyName, overrides.keyName)
+  );
+  const current = carryCurrent(existing, ["itemId", "resources", "routes", "glossaryIds", "context", "isPartiallyTranslated"]);
+
+  const merged: Record<string, unknown> = { ...current, ...overrides };
+  const body = value && culture ? { ...merged, resources: upsertResource(merged.resources, culture, value) } : merged;
 
   if (booleanFlag(flags, "dry-run")) {
     writeOutput({ dryRun: true, endpoint: "/localization/v4/Key/Save", request: body }, flags);
@@ -35,7 +61,6 @@ export async function localizationKeySave(argv: string[]): Promise<void> {
   }
 
   await confirmMutation(flags, `Save localization key '${body.keyName}'.`);
-  const projectTenantId = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/localization/v4/Key/Save", {
     body,
     impersonatedProjectAuth: true,
@@ -43,4 +68,15 @@ export async function localizationKeySave(argv: string[]): Promise<void> {
     projectTenantId
   });
   writeOutput(result, flags);
+}
+
+/**
+ * Replaces the translation for `culture` (matched case-insensitively, keeping the stored
+ * spelling) or appends one; every other culture's translation is kept as-is.
+ */
+function upsertResource(resources: unknown, culture: string, value: string): Record<string, unknown>[] {
+  const list = Array.isArray(resources) ? resources.filter(isRecord) : [];
+  const index = list.findIndex((item) => sameName(item.culture, culture));
+  if (index === -1) return [...list, { characterLength: value.length, culture, value }];
+  return list.map((item, position) => (position === index ? { ...item, characterLength: value.length, value } : item));
 }

--- a/blocks-cli/src/commands/localization/language/save.ts
+++ b/blocks-cli/src/commands/localization/language/save.ts
@@ -2,13 +2,14 @@ import { booleanFlag, optionalBooleanFlag, stringFlag } from "../../../lib/args.
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag } from "../../../lib/json-flag.js";
+import { carryCurrent, findInList } from "../../../lib/merge-current.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 
 export async function localizationLanguageSave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
-  const body = {
+  const overrides = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       isDefault: optionalBooleanFlag(flags, "is-default"),
@@ -18,7 +19,27 @@ export async function localizationLanguageSave(argv: string[]): Promise<void> {
     })
   };
 
-  if (!body.languageName) throw new Error("Provide --language-name (or set it in --body/--file).");
+  if (!overrides.languageName) throw new Error("Provide --language-name (or set it in --body/--file).");
+
+  const projectTenantId = await selectedProject(flags);
+
+  // Language/Save upserts by LanguageName and assigns IsDefault from the request, a
+  // non-nullable bool -- re-saving the default language without --is-default silently
+  // demoted it, leaving the tenant with no default. There is no GET by name, so the
+  // current record comes from the list. The match is exact (case included) because the
+  // server's own lookup is a Mongo Eq: a differently-cased name is a CREATE there, and
+  // carrying this record's isDefault into it would mint a second default language.
+  const existing = findInList(
+    await blocksRequest<unknown>("/localization/v4/Language/Gets", {
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId
+    }),
+    (item) => item.languageName === overrides.languageName
+  );
+  const current = carryCurrent(existing, ["itemId", "languageCode", "isDefault"]);
+
+  const body = { ...current, ...overrides };
   if (!body.languageCode) throw new Error("Provide --language-code (or set it in --body/--file).");
 
   if (booleanFlag(flags, "dry-run")) {
@@ -27,7 +48,6 @@ export async function localizationLanguageSave(argv: string[]): Promise<void> {
   }
 
   await confirmMutation(flags, `Save language '${body.languageName}' (${body.languageCode}).`);
-  const projectTenantId = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/localization/v4/Language/Save", {
     body,
     impersonatedProjectAuth: true,

--- a/blocks-cli/src/commands/mail/config/save.ts
+++ b/blocks-cli/src/commands/mail/config/save.ts
@@ -2,6 +2,7 @@ import { booleanFlag, optionalBooleanFlag, optionalIntegerFlag, stringFlag } fro
 import { blocksRequest } from "../../../lib/api.js";
 import { confirmMutation } from "../../../lib/confirm.js";
 import { compact, jsonBodyFlag } from "../../../lib/json-flag.js";
+import { carryCurrent, findInList } from "../../../lib/merge-current.js";
 import { redactSecrets } from "../../../lib/redact.js";
 import { writeOutput } from "../../../lib/output.js";
 import { requestContext } from "../../../lib/request-context.js";
@@ -9,7 +10,7 @@ import { parseCommand, selectedProject } from "../../../lib/workspace.js";
 
 export async function mailConfigSave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
-  const body = {
+  const overrides = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       accountPassword: stringFlag(flags, "account-password") || undefined,
@@ -25,6 +26,37 @@ export async function mailConfigSave(argv: string[]): Promise<void> {
       senderUserName: stringFlag(flags, "sender-username") || undefined
     })
   };
+
+  const configurationId = typeof overrides.configurationId === "string" ? overrides.configurationId : undefined;
+
+  // Mail/Save with a configurationId rewrites the configuration from the request. Host,
+  // Port, the sender fields and AccountPassword are validated as required, so leaving
+  // those out fails loudly -- but EnableSSL, IsInbound and IsEnableSnsConfiguration are
+  // non-nullable bools and Provider an enum, so a host-only update silently turned SSL
+  // off, flipped an inbound configuration to outbound, reset the provider and dropped
+  // the SNS wiring. There is no GET by id; the current record comes from Mail/Gets,
+  // which returns the stored MailServerConfiguration
+  // ENTITY rather than the request DTO -- its `itemId` is the DTO's `configurationId`
+  // and its `name` the DTO's `configurationName`. AccountPassword is not carried: the
+  // API returns it masked and storing the mask would break sending, so an update still
+  // passes --account-password (which the server requires regardless). A new
+  // configuration has nothing to read, so its dry-run stays offline.
+  const current = configurationId
+    ? carryCurrent(
+        findInList(
+          await blocksRequest<unknown>("/os/v4/Mail/Gets", {
+            impersonatedProjectAuth: true,
+            ...requestContext(flags),
+            projectTenantId: await selectedProject(flags)
+          }),
+          (item) => item.itemId === configurationId
+        ),
+        ["name", "host", "port", "enableSSL", "senderName", "senderAddress", "senderUserName", "isInbound", "provider", "isEnableSnsConfiguration"],
+        { name: "configurationName" }
+      )
+    : {};
+
+  const body = { ...current, ...overrides };
 
   if (booleanFlag(flags, "dry-run")) {
     writeOutput({ dryRun: true, endpoint: "/os/v4/Mail/Save", request: redactSecrets(body) }, flags);

--- a/blocks-cli/src/commands/notification/save.ts
+++ b/blocks-cli/src/commands/notification/save.ts
@@ -2,13 +2,14 @@ import { booleanFlag, optionalBooleanFlag, optionalIntegerFlag, stringFlag } fro
 import { blocksRequest } from "../../lib/api.js";
 import { confirmMutation } from "../../lib/confirm.js";
 import { compact, jsonBodyFlag } from "../../lib/json-flag.js";
+import { carryCurrent, findInList } from "../../lib/merge-current.js";
 import { writeOutput } from "../../lib/output.js";
 import { requestContext } from "../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../lib/workspace.js";
 
 export async function notificationSave(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
-  const body = {
+  const overrides = {
     ...(await jsonBodyFlag(flags)),
     ...compact({
       channelToNotify: optionalIntegerFlag(flags, "channel"),
@@ -20,13 +21,29 @@ export async function notificationSave(argv: string[]): Promise<void> {
     })
   };
 
+  const projectKey = await selectedProject(flags);
+
+  // Notification/Save upserts by Name and assigns ChannelToNotify, NotificationType and
+  // EnablePersistence from the request -- two enums and a bool, all non-nullable -- so
+  // re-saving a configuration by name to change one of them reset the other two.
+  // Gets has no name filter, so the pages are walked until the name turns up. The
+  // match is exact (case included) because the server's own lookup is a Mongo Eq: a
+  // differently-cased name is a CREATE there, and carrying another record's fields
+  // into it would be wrong.
+  const existing = typeof overrides.name === "string" ? await findNotificationByName(overrides.name, projectKey, flags) : undefined;
+  const current = carryCurrent(existing, ["channelToNotify", "notificationType", "enablePersistence", "notifyMethod"]);
+
+  // The save validator rejects an already-taken name unless IsUpdateRequest is set, so
+  // finding the record IS the update intent -- default it, still overridable by
+  // --update=false or --body.
+  const body = { ...(existing ? { isUpdateRequest: true } : {}), ...current, ...overrides };
+
   if (booleanFlag(flags, "dry-run")) {
     writeOutput({ dryRun: true, endpoint: "/os/v4/Notification/Save", request: body }, flags);
     return;
   }
 
   await confirmMutation(flags, `Save notification configuration '${body.name ?? ""}'.`);
-  const projectKey = await selectedProject(flags);
   const result = await blocksRequest<unknown>("/os/v4/Notification/Save", {
     body,
     impersonatedProjectAuth: true,
@@ -34,4 +51,33 @@ export async function notificationSave(argv: string[]): Promise<void> {
     projectTenantId: projectKey
   });
   writeOutput(result, flags);
+}
+
+async function findNotificationByName(
+  name: string,
+  projectKey: string,
+  flags: Record<string, string | boolean>
+): Promise<Record<string, unknown> | undefined> {
+  const pageSize = 100;
+  // The repository skips PageSize * Page, so the first page is 0. A short page means
+  // the list is exhausted; the cap only guards against a server that never returns one.
+  for (let page = 0; page < 50; page += 1) {
+    const response = await blocksRequest<unknown>("/os/v4/Notification/Gets", {
+      impersonatedProjectAuth: true,
+      ...requestContext(flags),
+      projectTenantId: projectKey,
+      query: { Page: page, PageSize: pageSize }
+    });
+    const match = findInList(response, (item) => item.name === name);
+    if (match) return match;
+    if (countRows(response) < pageSize) return undefined;
+  }
+  return undefined;
+}
+
+function countRows(response: unknown): number {
+  if (Array.isArray(response)) return response.length;
+  if (!response || typeof response !== "object") return 0;
+  const list = Object.values(response as Record<string, unknown>).find(Array.isArray);
+  return Array.isArray(list) ? list.length : 0;
 }

--- a/blocks-cli/src/commands/notifier/unread.ts
+++ b/blocks-cli/src/commands/notifier/unread.ts
@@ -4,9 +4,12 @@ import { writeOutput } from "../../lib/output.js";
 import { requestContext } from "../../lib/request-context.js";
 import { parseCommand, selectedProject } from "../../lib/workspace.js";
 
-// Swagger documents GetUnreadNotificationsBySubscriptionFilter as GET with a JSON
-// request body, which the Fetch spec forbids sending on a GET request. Sent as a
-// flattened query string instead, matching every other GET endpoint in this API.
+// blocks-logic declares GetUnreadNotificationsBySubscriptionFilter as [HttpGet] with a
+// [FromBody] request -- a combination fetch cannot send (GET bodies are forbidden by
+// the Fetch spec). The flattened query below is the closest a client can get, but the
+// server binds from the body, so until blocks-logic switches to [FromQuery] the
+// filters do not reach it and the request is likely rejected as missing its body.
+// Kept as a query so the command starts working the moment the server side is fixed.
 export async function notifierUnread(argv: string[]): Promise<void> {
   const { flags } = parseCommand(argv);
   const projectKey = await selectedProject(flags);

--- a/blocks-cli/src/commands/storage/config/delete.ts
+++ b/blocks-cli/src/commands/storage/config/delete.ts
@@ -16,9 +16,12 @@ export async function storageConfigDelete(argv: string[]): Promise<void> {
 
   await confirmMutation(flags, `Delete storage configuration '${name}'.`);
   const projectKey = await selectedProject(flags);
+  // Storage/Delete is [HttpPost] with [FromQuery] ConfigurationName in blocks-os --
+  // unlike Mail/Delete and Notification/Delete, which are [HttpDelete]. A DELETE here
+  // gets 405.
   const result = await blocksRequest<unknown>("/os/v4/Storage/Delete", {
     impersonatedProjectAuth: true,
-    method: "DELETE",
+    method: "POST",
     ...requestContext(flags),
     projectTenantId: projectKey,
     query: { ConfigurationName: name }

--- a/blocks-cli/src/lib/auth.ts
+++ b/blocks-cli/src/lib/auth.ts
@@ -450,7 +450,7 @@ async function postStopImpersonation(apiUrl: string, accessToken: string, accoun
 }
 
 async function postLogout(apiUrl: string, accessToken: string, accountTenant: string, refreshToken: string): Promise<void> {
-  const response = await fetch(new URL("/iam/v4/api/auth/logout", apiUrl), {
+  const response = await fetch(new URL("/iam/v4/auth/logout", apiUrl), {
     body: JSON.stringify({ refresh_token: refreshToken }),
     headers: {
       Accept: "application/json",

--- a/blocks-cli/src/lib/merge-current.ts
+++ b/blocks-cli/src/lib/merge-current.ts
@@ -1,0 +1,63 @@
+import { isRecord } from "./data-response.js";
+
+/**
+ * Several Blocks save/update endpoints bind the request onto a fresh DTO and then
+ * assign every DTO field onto the stored document. A field the caller left out does
+ * not mean "keep": it arrives as the C# default -- false, 0, "" or an empty list --
+ * and overwrites what was stored. `iam permissions update`, `auth config save` and
+ * `auth oidc-clients save` already read the current document and merge over it for
+ * exactly that reason; this is the shared shape for the rest.
+ *
+ * Only the named keys are carried so read-only metadata (ids, timestamps, counts,
+ * masked secrets) is never echoed back at the API. `rename` maps a key as the GET
+ * spells it onto the name the POST binds, for endpoints whose two halves disagree.
+ */
+export function carryCurrent(
+  current: unknown,
+  keys: readonly string[],
+  rename: Record<string, string> = {}
+): Record<string, unknown> {
+  const source = unwrapData(current);
+  const carried: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = source[key];
+    if (value === undefined || value === null) continue;
+    carried[rename[key] ?? key] = value;
+  }
+  return carried;
+}
+
+/** Peels one `{ data: {...} }` envelope when present; anything that is not an object reads as empty. */
+export function unwrapData(response: unknown): Record<string, unknown> {
+  if (!isRecord(response)) return {};
+  return isRecord(response.data) ? response.data : response;
+}
+
+/**
+ * Finds one record in a list response -- a bare array, or an envelope whose first
+ * array-valued property holds the rows (`keys`, `configurations`, `data`, ...).
+ * For the endpoints that have no GET-by-id and can only be read back as a list.
+ */
+export function findInList(
+  response: unknown,
+  predicate: (item: Record<string, unknown>) => boolean
+): Record<string, unknown> | undefined {
+  const items = Array.isArray(response)
+    ? response
+    : isRecord(response)
+      ? Object.values(response).find(Array.isArray)
+      : undefined;
+  return (items ?? []).filter(isRecord).find(predicate);
+}
+
+/**
+ * Case-insensitive equality -- ONLY for values the server has already matched exactly
+ * (key save's GetsByKeyNames rows) or that the CLI itself keys (a key's per-culture
+ * resources, where case-blind matching avoids near-duplicate culture entries). Never
+ * use it to pick the record a name-keyed upsert will hit: the servers' Mongo Eq
+ * lookups are case-sensitive, so a case-insensitive pick can carry one record's
+ * fields into what the server then treats as a create.
+ */
+export function sameName(value: unknown, expected: unknown): boolean {
+  return typeof value === "string" && typeof expected === "string" && value.toLowerCase() === expected.toLowerCase();
+}

--- a/blocks-cli/src/lib/release.ts
+++ b/blocks-cli/src/lib/release.ts
@@ -2,7 +2,7 @@ import { blocksRequest } from "./api.js";
 import { CliActionableError } from "./errors.js";
 import { requestContext } from "./request-context.js";
 
-export const RELEASE_API = "/release/v4/api";
+export const RELEASE_API = "/release/v4";
 
 type Flags = Record<string, string | boolean>;
 

--- a/blocks-cli/test/cli.test.mjs
+++ b/blocks-cli/test/cli.test.mjs
@@ -803,6 +803,432 @@ test("auth config explicit false survives fetch-and-merge", async () => {
   }
 });
 
+test("iam signup-settings save merges the current settings and renames the GET list fields", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/iam/v4/iam/signup-settings" && request.method === "GET") {
+      return {
+        isSignUpEnable: true,
+        isEmailPasswordSignUpEnabled: true,
+        isSSoSignUpEnabled: false,
+        defaultRolesForNewUser: ["member"],
+        defaultPermissionsForNewUser: ["profile::read"]
+      };
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
+    const rolesOnly = await runAsync(["iam", "signup-settings", "save", "--default-roles", "participant", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(rolesOnly.status, 0, rolesOnly.stderr);
+    // The POST binds `...OnSignUp`; the GET's spelling and its derived `isSignUpEnable` must not leak through.
+    assert.deepEqual(JSON.parse(rolesOnly.stdout).request, {
+      isEmailPasswordSignUpEnabled: true,
+      isSSoSignUpEnabled: false,
+      defaultRolesForNewUserOnSignUp: ["participant"],
+      defaultPermissionsForNewUserOnSignUp: ["profile::read"]
+    });
+
+    const explicitFalse = await runAsync(["iam", "signup-settings", "save", "--email-password-signup=false", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(explicitFalse.status, 0, explicitFalse.stderr);
+    const request = JSON.parse(explicitFalse.stdout).request;
+    assert.equal(request.isEmailPasswordSignUpEnabled, false);
+    assert.deepEqual(request.defaultRolesForNewUserOnSignUp, ["member"]);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("iam users update is a sparse patch: sends only the passed fields and refuses retired ones", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const urls = [];
+  // POST /users/{id} keeps omitted fields server-side, so the dry-run must not read the
+  // user first -- any request against this server is a failure.
+  const server = await startJsonServer((request) => {
+    urls.push(`${request.method} ${request.url}`);
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${request.url}` });
+  });
+
+  try {
+    const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
+    const result = await runAsync([
+      "iam", "users", "update", "user-1", "--first-name", "Grace", "--organization-id", "org-7", "--dry-run", "--api-url", server.url, "--json"
+    ], { cwd, env });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(urls, [], "sparse update must not call the API on --dry-run");
+    assert.deepEqual(JSON.parse(result.stdout).request, {
+      itemId: "user-1",
+      firstName: "Grace",
+      organizationId: "org-7"
+    });
+
+    // Roles/permissions/MFA were retired from this endpoint: the server ignores them
+    // with only a log line, so the CLI turns that silence into a typed error.
+    const roles = await runAsync(["iam", "users", "update", "user-1", "--roles", "editor", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(roles.status, 1);
+    assert.match(roles.stderr, /access grant/);
+
+    const body = await runAsync([
+      "iam", "users", "update", "user-1", "--body", JSON.stringify({ firstName: "Grace", mfaEnabled: false }), "--dry-run", "--api-url", server.url, "--json"
+    ], { cwd, env });
+    assert.equal(body.status, 1);
+    assert.match(body.stderr, /mfaEnabled/);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("iam roles update keeps description, parent and canCreateOwn on a rename", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/iam/v4/iam/roles/role-1" && request.method === "GET") {
+      return {
+        data: {
+          itemId: "role-1",
+          name: "Content Editor",
+          slug: "content-editor",
+          description: "Edits published content",
+          parentRoleSlug: "editor",
+          canCreateOwn: false,
+          count: 12,
+          ancestorRoleSlugs: ["editor", "admin"]
+        }
+      };
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const result = await runAsync(["iam", "roles", "update", "role-1", "--name", "Content Lead", "--dry-run", "--api-url", server.url, "--json"], {
+      cwd,
+      env: testEnv(configDir, { BLOCKS_SECRET_STORE: "file" })
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).request, {
+      itemId: "role-1",
+      name: "Content Lead",
+      description: "Edits published content",
+      parentRoleSlug: "editor",
+      canCreateOwn: false
+    });
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("auth client-credentials save merges the stored credential and never carries its secret", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/iam/v4/auth/client-credentials" && request.method === "GET") {
+      return [
+        {
+          itemId: "cc-1",
+          name: "ci-deployer",
+          clientSecret: "blxsk_live_secret_value",
+          isActive: false,
+          accessTokenValidForNumberMinutes: 30,
+          roles: ["deployer"],
+          permissions: ["release::deploy"]
+        }
+      ];
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
+    const result = await runAsync([
+      "auth", "client-credentials", "save", "--item-id", "cc-1", "--roles", "deployer,reader", "--dry-run", "--api-url", server.url, "--json"
+    ], { cwd, env });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).request, {
+      itemId: "cc-1",
+      name: "ci-deployer",
+      isActive: false,
+      accessTokenValidForNumberMinutes: 30,
+      roles: ["deployer", "reader"],
+      permissions: ["release::deploy"]
+    });
+    assert.ok(!result.stdout.includes("blxsk_live_secret_value"), "client secret leaked into the save body");
+
+    const missing = await runAsync(["auth", "client-credentials", "save", "--item-id", "cc-404", "--roles", "reader", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(missing.status, 1);
+    assert.match(missing.stderr, /cc-404.*was not found/);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("localization key save upserts one culture and keeps the other translations", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const lookups = [];
+  const server = await startJsonServer((request, body) => {
+    const path = request.url.split("?")[0];
+    if (path === "/localization/v4/Key/GetsByKeyNames" && request.method === "POST") {
+      lookups.push(body);
+      return {
+        keys: [
+          {
+            itemId: "key-1",
+            keyName: "greeting",
+            moduleId: "mod-1",
+            resources: [
+              { culture: "en-US", value: "Hello", characterLength: 5 },
+              { culture: "de-DE", value: "Hallo", characterLength: 5 }
+            ],
+            routes: ["/home"],
+            glossaryIds: ["g-1"],
+            context: "Landing page header",
+            isPartiallyTranslated: true
+          }
+        ]
+      };
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
+    const added = await runAsync([
+      "localization", "key", "save", "--key-name", "greeting", "--module-id", "mod-1", "--value", "Bonjour", "--culture", "fr-FR", "--dry-run", "--api-url", server.url, "--json"
+    ], { cwd, env });
+    assert.equal(added.status, 0, added.stderr);
+    assert.deepEqual(lookups[0], { keyNames: ["greeting"], moduleId: "mod-1" });
+    assert.deepEqual(JSON.parse(added.stdout).request, {
+      itemId: "key-1",
+      keyName: "greeting",
+      moduleId: "mod-1",
+      resources: [
+        { culture: "en-US", value: "Hello", characterLength: 5 },
+        { culture: "de-DE", value: "Hallo", characterLength: 5 },
+        { characterLength: 7, culture: "fr-FR", value: "Bonjour" }
+      ],
+      routes: ["/home"],
+      glossaryIds: ["g-1"],
+      context: "Landing page header",
+      isPartiallyTranslated: true
+    });
+
+    const replaced = await runAsync([
+      "localization", "key", "save", "--key-name", "greeting", "--module-id", "mod-1", "--value", "Servus", "--culture", "de-de", "--dry-run", "--api-url", server.url, "--json"
+    ], { cwd, env });
+    assert.equal(replaced.status, 0, replaced.stderr);
+    assert.deepEqual(JSON.parse(replaced.stdout).request.resources, [
+      { culture: "en-US", value: "Hello", characterLength: 5 },
+      { culture: "de-DE", value: "Servus", characterLength: 6 }
+    ]);
+
+    const noCulture = await runAsync(["localization", "key", "save", "--key-name", "greeting", "--module-id", "mod-1", "--value", "Hola", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(noCulture.status, 1);
+    assert.match(noCulture.stderr, /--culture/);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("captcha save <id> merges the stored configuration so a secret rotation does not disable it", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/os/v4/captcha/get/cfg-1" && request.method === "GET") {
+      return { id: "cfg-1", isEnable: true, provider: "recaptcha", captchaKey: "site-1", captchaGenerator: "v3", secretId: "sec-1" };
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const result = await runAsync(["captcha", "save", "cfg-1", "--captcha-secret", "rotated-secret-99", "--dry-run", "--api-url", server.url, "--json"], {
+      cwd,
+      env: testEnv(configDir, { BLOCKS_SECRET_STORE: "file" })
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const planned = JSON.parse(result.stdout);
+    assert.deepEqual(planned.request, {
+      id: "cfg-1",
+      isEnable: true,
+      provider: "recaptcha",
+      captchaKey: "site-1",
+      captchaGenerator: "v3",
+      captchaSecret: "***"
+    });
+    assert.equal(planned.secretHandling, "rotate the linked secret");
+    assert.ok(!result.stdout.includes("rotated-secret-99"), "captcha secret leaked to dry-run output");
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("iam users access grant shows the lists a non-empty grant will replace", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/iam/v4/iam/users/user-1" && request.method === "GET") {
+      return { data: { itemId: "user-1", roles: ["admin", "editor"], permissions: ["orders::export"] } };
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const result = await runAsync(["iam", "users", "access", "grant", "user-1", "--roles", "editor", "--dry-run", "--api-url", server.url, "--json"], {
+      cwd,
+      env: testEnv(configDir, { BLOCKS_SECRET_STORE: "file" })
+    });
+    assert.equal(result.status, 0, result.stderr);
+    const planned = JSON.parse(result.stdout);
+    assert.deepEqual(planned.current, { permissions: ["orders::export"], roles: ["admin", "editor"] });
+    assert.deepEqual(planned.request, { roles: ["editor"], userId: "user-1" });
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("mail config save --configuration-id merges the stored entity (itemId/name) and never carries the masked password", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/os/v4/Mail/Gets" && request.method === "GET") {
+      // Mail/Gets returns MailServerConfiguration entities, not the save DTO: `itemId` and
+      // `name` here are `configurationId` and `configurationName` on the request.
+      return [
+        {
+          itemId: "mail-1",
+          name: "primary",
+          host: "smtp.example.test",
+          port: 465,
+          enableSSL: true,
+          senderName: "Blocks",
+          senderAddress: "noreply@example.test",
+          senderUserName: "smtp-user",
+          accountPassword: "********",
+          isInbound: true,
+          provider: 2,
+          isEnableSnsConfiguration: true,
+          useDefaultCredentials: false,
+          isDefault: true
+        }
+      ];
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const result = await runAsync([
+      "mail", "config", "save", "--configuration-id", "mail-1", "--host", "smtp2.example.test", "--account-password", "new-pass-1", "--dry-run", "--api-url", server.url, "--json"
+    ], { cwd, env: testEnv(configDir, { BLOCKS_SECRET_STORE: "file" }) });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).request, {
+      configurationId: "mail-1",
+      configurationName: "primary",
+      host: "smtp2.example.test",
+      port: 465,
+      enableSSL: true,
+      senderName: "Blocks",
+      senderAddress: "noreply@example.test",
+      senderUserName: "smtp-user",
+      isInbound: true,
+      provider: 2,
+      isEnableSnsConfiguration: true,
+      accountPassword: "***"
+    });
+    assert.ok(!result.stdout.includes("new-pass-1"), "account password leaked to dry-run output");
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("notification save merges by exact name and marks the save as an update", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/os/v4/Notification/Gets" && request.method === "GET") {
+      return {
+        configurations: [
+          { itemId: "n-1", name: "order-events", channelToNotify: 2, notificationType: 1, enablePersistence: true, notifyMethod: "signalr" }
+        ],
+        totalCount: 1,
+        isSuccess: true
+      };
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
+    const updated = await runAsync(["notification", "save", "--name", "order-events", "--channel", "1", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(updated.status, 0, updated.stderr);
+    // The save validator rejects an existing name unless IsUpdateRequest is set, so
+    // finding the record must set it -- and the other enums/bool must carry over.
+    assert.deepEqual(JSON.parse(updated.stdout).request, {
+      isUpdateRequest: true,
+      channelToNotify: 1,
+      notificationType: 1,
+      enablePersistence: true,
+      notifyMethod: "signalr",
+      name: "order-events"
+    });
+
+    // The server's name lookup is a case-sensitive Eq: a differently-cased name is a
+    // CREATE there, so nothing may be carried and isUpdateRequest must stay unset.
+    const cased = await runAsync(["notification", "save", "--name", "Order-Events", "--channel", "1", "--notify-method", "signalr", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(cased.status, 0, cased.stderr);
+    assert.deepEqual(JSON.parse(cased.stdout).request, {
+      channelToNotify: 1,
+      name: "Order-Events",
+      notifyMethod: "signalr"
+    });
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+test("localization language save merges by exact name so a cased variant cannot inherit isDefault", async () => {
+  const { cwd, configDir } = await makeWorkspace();
+  await writeProjectAuth(configDir);
+  const server = await startJsonServer((request) => {
+    const path = request.url.split("?")[0];
+    if (path === "/localization/v4/Language/Gets" && request.method === "GET") {
+      return [{ itemId: "lang-1", languageName: "english", languageCode: "en-US", isDefault: true }];
+    }
+    return rawResponse(500, { errorMessage: `Unexpected ${request.method} ${path}` });
+  });
+
+  try {
+    const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
+    const resaved = await runAsync(["localization", "language", "save", "--language-name", "english", "--language-code", "en-GB", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(resaved.status, 0, resaved.stderr);
+    assert.deepEqual(JSON.parse(resaved.stdout).request, {
+      itemId: "lang-1",
+      languageCode: "en-GB",
+      isDefault: true,
+      languageName: "english"
+    });
+
+    // Language/Save's lookup is a case-sensitive Eq: "English" would CREATE a second
+    // language, which must not be born holding this record's isDefault.
+    const cased = await runAsync(["localization", "language", "save", "--language-name", "English", "--language-code", "en-GB", "--dry-run", "--api-url", server.url, "--json"], { cwd, env });
+    assert.equal(cased.status, 0, cased.stderr);
+    assert.deepEqual(JSON.parse(cased.stdout).request, {
+      languageCode: "en-GB",
+      languageName: "English"
+    });
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
 test("iam me prefers project auth only when a project is resolved", async () => {
   const { cwd, configDir } = await makeWorkspace();
   const authorizations = [];
@@ -1624,7 +2050,6 @@ test("configuration boolean flags preserve explicit false values", async () => {
   const env = testEnv(configDir, { BLOCKS_SECRET_STORE: "file" });
   const cases = [
     [["iam", "organizations", "config", "save", "--multi-org-enabled=false", "--dry-run", "--json"], "isMultiOrgEnabled"],
-    [["iam", "signup-settings", "save", "--email-password-signup=false", "--dry-run", "--json"], "isEmailPasswordSignUpEnabled"],
     [["mfa", "config", "save", "--enable=false", "--dry-run", "--json"], "enableMfa"],
     [["mail", "config", "save", "--enable-ssl=false", "--dry-run", "--json"], "enableSSL"]
   ];
@@ -1701,11 +2126,11 @@ test("release deploy wait polls with the explicitly deployed project session", a
     if (path === "/os/v4/Project/GetAsset") {
       return { assets: { resources: [{ name: "dev", resourceId: "repo-1" }] } };
     }
-    if (path === "/release/v4/api/Build/repo-details") {
+    if (path === "/release/v4/Build/repo-details") {
       return { data: { repo: { branch: "dev", repoUrl: "https://example.test/repo.git" } } };
     }
-    if (path === "/release/v4/api/Build/manual") return { buildId: "build-1" };
-    if (path === "/release/v4/api/Build") return { status: "completed" };
+    if (path === "/release/v4/Build/manual") return { buildId: "build-1" };
+    if (path === "/release/v4/Build") return { status: "completed" };
     return rawResponse(500, { error: `Unexpected ${request.method} ${path}` });
   });
 
@@ -1716,7 +2141,7 @@ test("release deploy wait polls with the explicitly deployed project session", a
       "--yes", "--wait", "--poll-interval", "0", "--json"
     ], { cwd, env: testEnv(configDir, { BLOCKS_SECRET_STORE: "file" }) });
     assert.equal(result.status, 0, result.stderr);
-    const poll = requests.find((item) => item.url.startsWith("/release/v4/api/Build?buildId="));
+    const poll = requests.find((item) => item.url.startsWith("/release/v4/Build?buildId="));
     assert.ok(poll, JSON.stringify(requests));
     assert.equal(poll.authorization, "Bearer alpha-target-token");
   } finally {
@@ -3855,11 +4280,11 @@ test("release deploy --wait reads the status field, not keywords in other string
     if (path === "/os/v4/Project/GetAsset") {
       return { assets: { resources: [{ name: "dev", resourceId: "repo-1" }] } };
     }
-    if (path === "/release/v4/api/Build/repo-details") {
+    if (path === "/release/v4/Build/repo-details") {
       return { data: { repo: { branch: "dev", repoUrl: "https://example.test/repo.git" } } };
     }
-    if (path === "/release/v4/api/Build/manual") return { buildId: "build-1" };
-    if (path === "/release/v4/api/Build") {
+    if (path === "/release/v4/Build/manual") return { buildId: "build-1" };
+    if (path === "/release/v4/Build") {
       buildPolls += 1;
       // First poll: still running, but full of strings the old keyword scan
       // misread as terminal (commit message, branch name).
@@ -3894,10 +4319,10 @@ test("release secrets sync merges over the current set and prints key names only
   const saves = [];
   const server = await startJsonServer((request, body) => {
     const path = request.url.split("?")[0];
-    if (path === "/release/v4/api/Build/repos-list") {
+    if (path === "/release/v4/Build/repos-list") {
       return { data: [{ branch: "dev", itemId: "repo-1", repoName: "web-app" }] };
     }
-    if (path === "/release/v4/api/RepoSecret/value") {
+    if (path === "/release/v4/RepoSecret/value") {
       // RepoSecretValueResponse: the set is the nested 'secrets' map, never the envelope.
       return {
         data: {
@@ -3907,7 +4332,7 @@ test("release secrets sync merges over the current set and prints key names only
         }
       };
     }
-    if (path === "/release/v4/api/RepoSecret/save") {
+    if (path === "/release/v4/RepoSecret/save") {
       saves.push(body);
       return { data: null, isSuccess: true };
     }
@@ -3961,7 +4386,7 @@ test("release teardown demands an explicit repo and confirms with the blast radi
   const deletes = [];
   const server = await startJsonServer((request) => {
     const path = request.url.split("?")[0];
-    if (path === "/release/v4/api/Build/repos-list") {
+    if (path === "/release/v4/Build/repos-list") {
       return {
         data: [
           { branch: "dev", customDeploymentUrl: "https://web.example.test", deployedNamespace: "ns-web-1", itemId: "repo-1", repoName: "web-app" },
@@ -3969,7 +4394,7 @@ test("release teardown demands an explicit repo and confirms with the blast radi
         ]
       };
     }
-    if (path === "/release/v4/api/Build/deployment" && request.method === "DELETE") {
+    if (path === "/release/v4/Build/deployment" && request.method === "DELETE") {
       deletes.push(request.url);
       return { data: null, isSuccess: true };
     }
@@ -4016,7 +4441,7 @@ test("release reports get only accepts the server's report types", async () => {
   const requests = [];
   const server = await startJsonServer((request) => {
     const path = request.url.split("?")[0];
-    if (path === "/release/v4/api/Build/reports") {
+    if (path === "/release/v4/Build/reports") {
       requests.push(request.url);
       return { data: { findings: 0 }, isSuccess: true };
     }
@@ -4052,17 +4477,17 @@ test("release secrets sync starts empty only on not-found and never saves over a
   let valueStatus = 403;
   const server = await startJsonServer((request, body) => {
     const path = request.url.split("?")[0];
-    if (path === "/release/v4/api/Build/repos-list") {
+    if (path === "/release/v4/Build/repos-list") {
       return { data: [{ branch: "dev", itemId: "repo-1", repoName: "web-app" }] };
     }
-    if (path === "/release/v4/api/RepoSecret/value") {
+    if (path === "/release/v4/RepoSecret/value") {
       // SecretExceptionFilter shape: {isSuccess:false, errors:{<key>: message, reason}}.
       if (valueStatus === 404) {
         return rawResponse(404, { errors: { not_found: "Secret 'repo-1' was not found.", reason: "NO_SECRET_FOR_REPO" }, isSuccess: false });
       }
       return rawResponse(valueStatus, { errors: { access_denied: "Forbidden." }, isSuccess: false });
     }
-    if (path === "/release/v4/api/RepoSecret/save") {
+    if (path === "/release/v4/RepoSecret/save") {
       saves.push(body);
       return { data: null, isSuccess: true };
     }
@@ -4108,17 +4533,17 @@ test("release deploy --with-secrets --json emits one document carrying the sync 
     if (path === "/os/v4/Project/GetAsset") {
       return { assets: { resources: [{ name: "dev", resourceId: "repo-1" }] } };
     }
-    if (path === "/release/v4/api/Build/repo-details") {
+    if (path === "/release/v4/Build/repo-details") {
       return { data: { repo: { branch: "dev", repoUrl: "https://example.test/repo.git" } } };
     }
-    if (path === "/release/v4/api/RepoSecret/value") {
+    if (path === "/release/v4/RepoSecret/value") {
       return { data: { repoId: "repo-1", secretId: "secret-9", secrets: { EXISTING_KEY: "existing-value-31" } } };
     }
-    if (path === "/release/v4/api/RepoSecret/save") {
+    if (path === "/release/v4/RepoSecret/save") {
       saves.push(body);
       return { data: null, isSuccess: true };
     }
-    if (path === "/release/v4/api/Build/manual") return { buildId: "build-7", isSuccess: true };
+    if (path === "/release/v4/Build/manual") return { buildId: "build-7", isSuccess: true };
     return rawResponse(500, { error: `Unexpected ${request.method} ${path}` });
   });
 

--- a/blocks-skills/blocks-captcha/SKILL.md
+++ b/blocks-skills/blocks-captcha/SKILL.md
@@ -29,7 +29,7 @@ blocks captcha get <id> --json
 |---|---|
 | `blocks captcha list` | All configurations plus `activeForLogin`. Read-only. |
 | `blocks captcha get <id>` | One configuration; `secretId` reference, never the secret. Read-only. |
-| `blocks captcha save [<id>] --provider p [--captcha-key k] [--captcha-secret s] [--generator g] --enable\|--enable=false` | Omit `<id>` to create, pass it to update. Mutating. |
+| `blocks captcha save [<id>] --provider p [--captcha-key k] [--captcha-secret s] [--generator g] --enable\|--enable=false` | Omit `<id>` to create, pass it to update. An update reads the stored record and merges, so `--captcha-secret` alone rotates the secret without disabling the configuration or blanking its site key; `--provider` is only required on create. Mutating. |
 | `blocks captcha enable <id>` / `blocks captcha disable <id>` | Flip only `isEnable`; nothing else changes. Mutating. |
 | `blocks captcha delete <id>` | Removes the record and retires its stored secret. Mutating. |
 

--- a/blocks-skills/blocks-data-gateway-configuration/SKILL.md
+++ b/blocks-skills/blocks-data-gateway-configuration/SKILL.md
@@ -29,7 +29,7 @@ blocks data config update --item-id <id> --connection-string "<new connection st
 blocks data config update --item-id <id> --connection-string "<new connection string>" --yes --json
 ```
 
-`data config update` also takes `--database-name`, `--collection-name-pattern`, and `--collection-name-editable` (boolean) — use these to rename the target database or adjust how collection names are derived/whether they're editable, on an existing configuration (`--item-id` required either way).
+`data config update` also takes `--database-name`, `--collection-name-pattern`, and `--collection-name-editable` (boolean) — use these to rename the target database or adjust how collection names are derived/whether they're editable, on an existing configuration (`--item-id` required either way). The update reads the current configuration and merges, so a connection-string-only change keeps `isCollectionNameEditable` and `collectionNamePattern` (the PUT would otherwise reset them to false/empty).
 
 Treat `--connection-string` as a secret: never print it back unredacted, and don't log it outside the command's own `--dry-run` preview (which redacts it).
 
@@ -92,7 +92,7 @@ blocks data reload --dry-run --json           # then reload so it's live
 blocks data reload --yes --json
 ```
 
-**Shortcut:** `blocks data sync --dry-run --json` then `--yes --json` runs validate → schema push → rules deploy → reload together in one confirmed step (see the schema workflow above for the full explanation) — use it instead of the manual deploy+reload above unless you need to run/inspect these steps individually.
+**Shortcut:** `blocks data sync` covers this too (validate → schema push → rules deploy → reload, one confirmation) — see the schema workflow above.
 
 `data rules deploy` applies schema security and data-access policies together — there's no finer-grained CLI split between "field access level" and "policy rule"; both live in `rules.json`.
 
@@ -151,9 +151,7 @@ blocks data schema delete <id> --yes --json
 
 `data schema info list/save/update` and `data schema fields` are the two-step alternative to `data schema push` (metadata first, fields second) — prefer the file-based `push` workflow above for normal schema authoring; reach for these only if the user specifically wants to add fields to an existing schema without touching its full JSON file, or needs the raw `/schemas/info` metadata-only shape.
 
-## `--dry-run` before `--yes` — always
-
-Every mutating command here (`data config create/update`, `data schema push`, `data schema delete`, `data schema fields`, `data schema info save/update`, `data rules deploy`, `data rules policy delete`, `data validation save/delete`, `data reload`) supports `--dry-run`. Run it, show the user what it says it will do, and only add `--yes` after they approve. This is not optional caution — it's the standard pattern across every `blocks` mutation, not unique to this skill.
+Every mutating command here supports `--dry-run`; run it, show the user, then `--yes` — the standard pattern across every `blocks` mutation.
 
 ## What this skill does NOT cover (and why)
 
@@ -161,8 +159,6 @@ Two things the old, pre-CLI version of this skill used to handle no longer have 
 
 - **Mock/sample data cleanup.** There is no `blocks data mock*` command, and the SDK's `data.utilities.mockData()` (in `@seliseblocks/client`) is **read-only** — it inventories mock data, it does not delete it. If a user asks to "wipe the demo data" or "clean up sample records," tell them plainly: this isn't exposed in the current CLI or SDK. Check whether the OS portal (`https://os.seliseblocks.com`) has a Data-section control for it; if not, there's no way to do this today short of deleting real records through generated GraphQL mutations one at a time, which is not the same thing and should not be presented as equivalent.
 - **Schema export/import between projects** (e.g. cloning a dev project's data model into staging). No CLI command and no SDK method exist for this. If a user wants to copy a data model between projects, the honest answer is: not supported by current tooling. Check the OS portal for a manual option; otherwise the only fallback is manually recreating schemas in the target project's `blocks/data/schemas/` and pushing them — which is a manual reconstruction, not a real export/import, and should be described as such.
-
-Don't guess at a raw API call to work around either gap — there is no supported path today, full stop.
 
 ## The one thing that goes through the SDK, not the CLI
 
@@ -182,17 +178,14 @@ const suggestion = await blocks.data.utilities.generateRegex({
 });
 ```
 
-If a user wants a regex suggestion for a field, write a small one-off script using the SDK like the above rather than trying to shoehorn it into a `blocks` invocation — the CLI genuinely has no equivalent, this isn't an oversight to work around. Once you have the pattern, put it into the relevant field's validation in `blocks/data/schemas/<Schema>.json` and continue with the normal push/reload workflow above.
+Once you have the pattern, put it into the relevant field's validation in `blocks/data/schemas/<Schema>.json` and continue with the normal push/reload workflow above — the CLI genuinely has no equivalent command.
 
 ## Gotchas
 
 - **Reload or it didn't happen.** `data schema push` and `data rules deploy` stage changes; `data reload` is what makes them visible to the runtime gateway (and to any app querying it via `@seliseblocks/client`).
-- **Pull before you edit** if you're not sure local files are current — someone may have changed the schema in the portal since your last pull.
 - **`data validate` is local-only** — it does not confirm the push will succeed against the server, only that the JSON is well-formed. Still run `--dry-run` on the actual push/deploy/reload commands.
-- **Don't invent mock-data-delete or schema-export commands.** They don't exist in the CLI or the SDK today — say so, check the portal, don't fake it with unrelated calls.
 - **Never define platform-managed system fields** (`ItemId`, `CreatedDate`, `CreatedBy`, `LastUpdatedDate`, `LastUpdatedBy`, `Language`, `OrganizationId`, `Tags`) in your schema JSON — Blocks adds these to every entity schema automatically.
 - **Check `data config get` before assuming Blocks-managed storage.** Most projects use it, but don't state it as fact without checking — and never create/update a data source configuration without explicit user intent, it repoints the project at a different database.
-- **`data validation save` requires a `validations` array via `--body`/`--file`.** There's no flag for it — the command errors out with a clear message if it's missing, don't try to work around that by guessing a flag name.
 
 ## Example trigger prompts
 

--- a/blocks-skills/blocks-iam-access-control/SKILL.md
+++ b/blocks-skills/blocks-iam-access-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blocks-iam-access-control
-description: "Work with SELISE Blocks RBAC (roles & permissions) via `blocks iam roles/permissions *` (CLI, project-scoped) or `blocksClient.iam.*` (SDK), never raw fetch/curl. Two facets: read-only feature-gating by the current user's own roles/permissions (common, safe), and creating/editing role and permission definitions (sensitive — CLI `--dry-run`→`--yes`, or an in-app admin screen). Use for permission-gated UI, role/permission pickers, or scripting role & permission admin. OIDC/identity-provider setup is a different skill."
+description: "Work with SELISE Blocks RBAC (roles & permissions) via `blocks iam roles/permissions *` (CLI, project-scoped) or `blocksClient.iam.*` (SDK), never raw fetch/curl. Two facets: read-only feature-gating by the current user's own roles/permissions (common, safe), and creating/editing role and permission definitions (sensitive — CLI `--dry-run`→`--yes`, or an in-app admin screen). Use for permission-gated UI, role/permission pickers, scripting role & permission admin, granting platform-seeded (built-in) permissions to custom roles, or diagnosing 403s / missing UI controls caused by an under-permissioned role. OIDC/identity-provider setup is a different skill."
 ---
 
 When invoking a project-scoped `blocks` command, either use the resolved account's saved selection or pass `--project <tenantId>` for that one command without changing saved state. `--project` applies to CLI commands only, never SDK calls.
@@ -34,12 +34,15 @@ Read-only, scoped to whoever is signed in, needs no special confirmation. `useCu
 
 Legitimate only in direct response to a human's explicit, in-the-moment instruction — CLI (`--dry-run` reviewed, then `--yes`) or a signed-in admin's own in-app screen. Never something an agent decides to invoke on its own initiative.
 
-→ Full command reference, SDK methods, and confirm-before-mutating pattern: [flows/manage-roles-permissions.md](flows/manage-roles-permissions.md)
+Sensitive means *confirmed*, not *refused*: **any permission the seeded `clouduser` system user holds is assignable to any role, with no restricted subset** — `isBuiltIn: true` and `clouduser` in a permission's `roles[]` are never grounds to decline a grant. The judgement call is *which* permissions a given role needs (`Endpoint` for the APIs its users call, `FrontendAction` for the UI they see, `DataProtection` for unmasked fields), not *whether* built-ins may be granted.
+
+→ Full command reference, SDK methods, choosing a role's permission set, 403 triage, and the confirm-before-mutating pattern: [flows/manage-roles-permissions.md](flows/manage-roles-permissions.md)
 
 ## Gotchas
 
 - **CLI mutations are project-scoped, not account-scoped** — they run against the impersonated-project token. `blocks iam me` prefers that token when a project resolves and uses the account token only without a resolved project.
 - **Role hierarchy and permission assignment key off `slug`**, not `itemId`.
+- **Match the permission type to the symptom.** `--type 1` Endpoint is gateway-enforced (missing ⇒ **403**); `--type 2` FrontendAction is SPA-gate-enforced (missing ⇒ control silently hidden); `--type 3` DataProtection controls masking (missing ⇒ redacted data). Most features need the type 1 *and* type 2 permission, plus any `dependentPermissions`.
 - **Never fire a create/update/assign-permissions call — CLI or SDK — without a human confirming that specific change first.** See [flows/manage-roles-permissions.md](flows/manage-roles-permissions.md) for the full discipline.
 - **OIDC/identity-provider client provisioning is a separate concern**, independent of everything above — it runs through `blocks auth oidc-clients`/`auth idp`, not through roles and permissions.
 
@@ -51,4 +54,6 @@ Legitimate only in direct response to a human's explicit, in-the-moment instruct
 - "Show me permissions grouped by severity in a settings panel." → Facet 1
 - "Build an admin page where I can create a role and pick which permissions it gets." → Facet 2
 - "Create a `content-editor` role from the CLI with these permissions." → Facet 2
+- "Users with the `support` role get 403 calling the inventory API — fix the role." → Facet 2; find the `--type 1` permission for that endpoint and grant it (plus its dependencies).
+- "Give the `manager` role everything `clouduser` has." → assignable, but push back on scope: propose the least-privilege set for what managers actually do and confirm that list first.
 - "Can you just set up a few default roles for my project?" → confirm the exact list with the human first (in chat, or via a reviewed `--dry-run`), then run each `blocks iam roles create`/`assign-permissions` with `--yes` only after they say go — don't auto-provision without that per-change confirmation.

--- a/blocks-skills/blocks-iam-access-control/flows/manage-roles-permissions.md
+++ b/blocks-skills/blocks-iam-access-control/flows/manage-roles-permissions.md
@@ -33,7 +33,54 @@ blocks iam permissions by-severity [--json]
 
 So `--severity 1` filters for the *most* dangerous permissions, not the least. Severity drives approval workflows (high-severity grants need an extra approver), UI emphasis, and audit-alert priority — it is not decorative.
 
+`roles update` reads the role first and merges your flags over it -- the endpoint replaces the role, so an unmerged rename would clear the description, detach the parent and turn `canCreateOwn` off. Omitting a flag keeps the stored value; pass it explicitly to clear it.
+
 Mutating commands (`create`, `update`, `assign-permissions`) follow the same discipline as every other mutating command in this CLI: pass `--dry-run` first to see the exact request body and endpoint with no network call, then re-run with `--yes` (or you'll be prompted to confirm) to actually send it.
+
+## Built-in permissions are assignable — every one of them
+
+**Rule: any permission held by the seeded `clouduser` system user can be assigned to any role. There is no restricted subset.** `clouduser` is seeded at project creation holding every service permission in the project, so it is the *catalog* of what exists — not a fence around it.
+
+Two fields get misread as "system-only". Neither is a restriction:
+
+- **`isBuiltIn: true`** means the permission was shipped/seeded by the platform rather than authored by this tenant. It says nothing about who may hold it. Granting built-in permissions to custom roles is the normal, intended way a role gets access to service APIs — not a workaround.
+- **`roles[]` containing `clouduser`** (or any other role) is a *membership list* — "these roles currently hold this permission". It is not an ACL on the permission, and it is not exclusive. Nearly every built-in permission lists `clouduser`, precisely because of the seed.
+
+**Refusing to assign is not the safe default.** A role whose users call an API they don't hold the `Endpoint` permission for gets a hard **403 from the gateway** — you ship a role that looks configured and is broken. Declining a built-in grant on "it's a system permission" grounds is a bug, not caution.
+
+The confirmation discipline is unchanged and still applies to every grant (reviewed `--dry-run`, then `--yes`, on the human's explicit instruction). What changes is that "built-in" and "clouduser has it" are never the reason to say no.
+
+## Choosing *which* permissions a role gets
+
+Unrestricted-to-assign is not assign-everything. Never clone `clouduser`'s set onto an application role, and never grant by keyword-matching a role's name. Work from what that role's users actually do:
+
+1. **Enumerate what the role must do** — the concrete API calls its users make and the screens/actions they see. If that isn't known yet, ask; don't guess a set.
+2. **Find the candidate permissions** — `blocks iam permissions list --resource-group <group>`, `--resources a,b`, `--search <text>`, or `--type <n>` to scope by kind. `blocks iam resources groups`/`blocks iam resources features` give you the resource/module grouping to walk. `blocks iam permissions by-severity` shows the same catalog bucketed by blast radius.
+3. **Match by permission type** — the type decides *what breaks* when a grant is missing, so it decides what you must include:
+
+   | `type` | Enforced by | Missing grant looks like | Grant it when |
+   |---|---|---|---|
+   | `1` Endpoint | API gateway | **403** on the call | the role's users hit that API at all — non-negotiable |
+   | `2` FrontendAction | the SPA's permission gate | no error; button/section silently hidden or disabled | the role should see and use that UI affordance |
+   | `3` DataProtection | field/record masking & encryption | data comes back masked/redacted | the role legitimately needs the unmasked field |
+
+   A role usually needs **both** the `Endpoint` permission and the matching `FrontendAction` — granting only the endpoint leaves an invisible button; granting only the frontend action leaves a button that 403s. Check for both when a feature spans API and UI.
+4. **Pull in `dependentPermissions`** — a permission whose dependencies aren't also granted still 403s. Read them off `blocks iam permissions get <id>` and include them in the same `--add-permissions` call.
+5. **Respect `severity`** — `1` is Critical (tenant-compromising), `4` is Low. High-severity grants are the ones worth naming explicitly in the confirmation you show the human; least privilege means preferring a narrow resource-scoped permission over a broad one when both would work.
+6. **Grant the delta, confirm, apply** — `assign-permissions` is additive/subtractive, so send only what's changing.
+
+### Triage: a role's users are getting 403
+
+1. Read the failing request's endpoint from the error, and find its permission: `blocks iam permissions list --type 1 --search <resource-or-endpoint-fragment> --json`.
+2. Confirm the role doesn't hold it: `blocks iam permissions list --roles <role-slug> --json`, or check `roles[]` on the permission.
+3. Grant it (plus its `dependentPermissions`) after showing the human the exact diff:
+
+```
+blocks iam roles assign-permissions <role-slug> --add-permissions <resource>,<dependency> --dry-run
+blocks iam roles assign-permissions <role-slug> --add-permissions <resource>,<dependency> --yes
+```
+
+If the API succeeds but the control never renders, it's the mirror-image case — a missing `--type 2` FrontendAction, not a 403.
 
 ## Two equally real surfaces
 
@@ -61,7 +108,7 @@ All from `blocksClient.iam`, per `iam-client.ts`:
 - `roles.assignable()` — same read method as feature-gating; also useful here to limit which roles this admin's screen lets them touch at all.
 - `resources.groups()` — metadata for grouping permissions by resource in the UI (e.g. a permissions picker organized by resource/module).
 
-The SDK deliberately leaves these request bodies as open `Record<string, unknown>` rather than locking you to a fixed shape — confirm exact field names against the portal or a `list()`/`get()` response before hardcoding new ones. Two fields the SDK's own types do pin down: a role's `slug` (`BlocksRole.slug`) is its stable key — use it, not `itemId`, anywhere the API expects a role reference (e.g. `assignPermissions`); a permission's `resource` and `roles[]` (`BlocksPermission`) tell you what it's scoped to and which roles already hold it.
+The SDK deliberately leaves these request bodies as open `Record<string, unknown>` rather than locking you to a fixed shape — confirm exact field names against the portal or a `list()`/`get()` response before hardcoding new ones. Two fields the SDK's own types do pin down: a role's `slug` (`BlocksRole.slug`) is its stable key — use it, not `itemId`, anywhere the API expects a role reference (e.g. `assignPermissions`); a permission's `resource` and `roles[]` (`BlocksPermission`) tell you what it's scoped to and which roles already hold it — `roles[]` is membership, never a restriction on who else may be granted it.
 
 ## Confirm before mutating
 
@@ -113,6 +160,8 @@ blocks iam roles assign-permissions editor --add-permissions content::publish --
 
 ## Gotchas
 
+- **Built-in grants:** the two rules above — assignable without a restricted subset, chosen by what the role actually does — are the sections "Built-in permissions are assignable" and "Choosing *which* permissions a role gets"; don't re-derive them here.
+- **A feature that spans API and UI needs both its `--type 1` and `--type 2` permissions** — endpoint-only leaves an invisible button, frontend-action-only leaves a button that 403s.
 - **CLI mutations are project-scoped, not account-scoped** — `blocks iam roles create/update/assign-permissions` and `blocks iam permissions create/update` all require a selected project (`blocks use <tenantId>` or `--project <tenantId>`) and run against the impersonated-project token. `blocks iam me` prefers the same mode when a project resolves and falls back to account auth only when none does.
 - **Role hierarchy and permission assignment key off `slug`**, not `itemId` — grab it from `roles.list()`/`roles.get()` (or `blocks iam roles list/get`) before calling `assignPermissions`.
 - **Permission assignment ultimately uses permission `itemId`s** — the CLI resolves `resource` strings like `content::publish` before mutation; SDK/backend callers should pass permission ids directly in `addPermissions` / `removePermissions`.

--- a/blocks-skills/blocks-iam-mfa/SKILL.md
+++ b/blocks-skills/blocks-iam-mfa/SKILL.md
@@ -152,7 +152,7 @@ There is no admin recovery. Backup codes (`backupCodes.use`, anonymous, needs `u
 
 `totp setup` → prints the QR/secret → **verification code** (from `--code`, or an interactive prompt if omitted) → `totp verify-setup <code>` → `method set --mfa-type <n>` → `backup-codes generate --yes`.
 
-Two things worth calling out precisely, both confirmed against source:
+Worth calling out precisely, confirmed against source:
 
 - **`--mfa-type` is required, never defaulted.** For this command it is `1` (TOTP) — the value the final `method set` step activates. The command throws rather than assuming it, so pass `--mfa-type 1` explicitly.
 - **The last step fails on a tenant that hasn't allowed backup codes.** `backup-codes generate` returns `backup_codes_disabled` unless `allowBackupCodes` is set in the tenant policy — enrollment itself already succeeded at that point, so treat it as "enrolled, no recovery codes" and fix the policy, not as a failed enrollment.
@@ -164,10 +164,6 @@ Deliberately excluded from this composed command: `mfa config save`. That's the 
 ## Gotchas
 
 - **`config`/`saveConfig` (SDK) and `mfa config get`/`config save` (CLI) are tenant policy, not a user's enrollment state.** Don't call these expecting to see or change one user's MFA status — that's every other method/command in this file. Reading policy needs `blocks-iam::iam::mfa-configs` and writing it `blocks-iam::iam::mutate-mfa-configs`, so an ordinary end user cannot fetch it from an app.
-- **`1` is TOTP and `2` is Email; `0` is None, and `3`/`4` have no provider.** Same enum for `mfaType`, `authType`, `userMfaType`, and a client's `allowedMfaMethods` — see the table above. `mfa method set` with anything but `1`/`2` disables the user's MFA.
-- **`mfa totp enable` needs both `--yes` and `--code` in non-interactive use** — see above. Missing approval or input fails clearly instead of waiting on stdin.
-- **Backup codes are shown once**, and only exist if the tenant set `allowBackupCodes` and the user is already enrolled — otherwise generate fails with `backup_codes_disabled` / `mfa_not_enrolled`. `list()` returns a remaining count, never the codes.
-- **No admin can enroll, reset, or disable another user's MFA.** Every self-service route resolves the user from the caller's own token; the one admin-reset code path IAM has is not wired to any route. The nearest lever is role-based policy (`mfaRequiredRoles`/`mfaExemptRoles`), which targets a role, not a user id — don't fabricate an endpoint to satisfy the request.
 - **Every `mfa` CLI command is project-scoped and impersonation-only**, same rule as the rest of the project-scoped CLI surface — `blocks use <tenantId>` first, or commands fail with `project_not_selected`.
 - **The CLI's self-service commands act on the CLI operator's own identity** inside the selected tenant, resolved from the impersonated token. `blocks mfa totp enable` enrolls *you*, not a customer. There is no CLI path to enroll someone else — that has to happen in the app, as that user.
 - **`mfa generate` on a tenant with MFA off** returns `{"errors":{"mfa_not_enable":"Please enable mfa for your application first"}}` — check `mfa config get` before assuming the method value was wrong.
@@ -180,7 +176,4 @@ Deliberately excluded from this composed command: `mfa config save`. That's the 
 - "Check whether this tenant requires MFA before showing the enrollment prompt."
 - "Turn on MFA for the whole tenant and require it for the admin role."
 - "Send an OTP code to the user and verify what they typed."
-- "Let a user regenerate their MFA backup codes."
-- "From the terminal, enroll the current project's impersonated user in TOTP MFA end to end."
-- "Run TOTP enrollment non-interactively from a script" → pass both `--yes` and `--code <c>` to `blocks mfa totp enable`, never run it unattended without them.
-- "Read the tenant's current MFA policy from the CLI."
+- "From the terminal, enroll the current project's impersonated user in TOTP MFA end to end" → `blocks mfa totp enable --mfa-type 1`; non-interactively, pass both `--yes` and `--code <c>`.

--- a/blocks-skills/blocks-iam-organizations/flows/admin-mutations.md
+++ b/blocks-skills/blocks-iam-organizations/flows/admin-mutations.md
@@ -69,7 +69,7 @@ For anything that isn't a feature inside a running Blocks app (one-off lookups, 
 | `blocks iam organizations config get` | `organizations.getConfig()` | Read-only. |
 | `blocks iam organizations config save [...]` | `organizations.saveConfig()` | `--multi-org-enabled`, `--consent-for-multi-org-enable`, `--allow-org-creation-from-signup`, `--allow-org-creation-from-portal`, `--allow-org-creation-from-cloud`, `--allow-org-creation-from-construct`, or `--body`/`--file`. Mutation. |
 | `blocks iam signup-settings get` | `signupSettings.get()` | Read-only. |
-| `blocks iam signup-settings save [...]` | `signupSettings.save()` | `--email-password-signup`, `--sso-signup`, `--default-permissions`, `--default-roles`, or `--body`/`--file`. Mutation. |
+| `blocks iam signup-settings save [...]` | `signupSettings.save()` | `--email-password-signup`, `--sso-signup`, `--default-permissions`, `--default-roles`, or `--body`/`--file`. Mutation. The CLI reads the current settings and merges, because the endpoint stores all four fields from the body (omitted booleans become false, omitted lists empty). SDK callers must send all four every time -- the GET spells the lists `defaultRolesForNewUser`/`defaultPermissionsForNewUser`, the POST needs `...OnSignUp`. |
 
 ```bash
 blocks use <tenantId>                              # select the project once per session

--- a/blocks-skills/blocks-iam-users/SKILL.md
+++ b/blocks-skills/blocks-iam-users/SKILL.md
@@ -53,7 +53,7 @@ Every method below mutates a real account. Before calling any of them, restate t
 | Method | What it does |
 |---|---|
 | `iam.users.create(request)` | Invites/provisions a user in the active tenant/organization. |
-| `iam.users.update(id, request)` | Edits an IAM profile's fields. |
+| `iam.users.update(id, request)` | Edits an IAM profile's fields. Sparse patch: an omitted or `null` field keeps the stored value, `""`/`[]` clears it. Roles, permissions and MFA state are ignored by this endpoint (the server only logs a warning) -- change access with `updateAccess` and MFA through the MFA methods. |
 | `iam.users.deactivate(request)` | Removes access without deleting the record. |
 | `iam.users.activate(request)` | Restores access for a previously deactivated account. |
 | `iam.users.updateAccess(request)` | Grants or changes roles/permissions/org access for a user. |
@@ -98,10 +98,10 @@ Mutations — every one supports `--dry-run` (print the request body and exit, n
 | Command | What it does |
 |---|---|
 | `blocks iam users create --email <e>\|--user-name <n> [--first-name] [--last-name] [--password] [--phone-number] [--organization-id] [--roles a,b] [--permissions a,b] [--body '<json>'\|--file <path>] [--dry-run] [--yes] [--json]` | Invites/provisions a user. |
-| `blocks iam users update <id> [--first-name] [--last-name] [--phone-number] [--organization-id] [--roles a,b] [--permissions a,b] [--body '<json>'\|--file <path>] [--dry-run] [--yes] [--json]` | Edits an IAM profile's fields. |
+| `blocks iam users update <id> [--first-name] [--last-name] [--phone-number] [--organization-id] [--body '<json>'\|--file <path>] [--dry-run] [--yes] [--json]` | Edits an IAM profile's fields. The endpoint is a sparse patch: omitted fields are kept, `""` via `--body` clears one. `--roles`/`--permissions`/MFA fields are rejected here (the endpoint ignores them) -- use `access grant` and the MFA commands. |
 | `blocks iam users activate <userId> [--reason <text>] [--dry-run] [--yes] [--json]` | Restores access for a previously deactivated account. |
 | `blocks iam users deactivate <userId> [--dry-run] [--yes] [--json]` | Removes access without deleting the record. |
-| `blocks iam users access grant <userId> [--roles a,b] [--permissions a,b] [--organization-id] [--dry-run] [--yes] [--json]` | Grants roles/permissions/org access (requires at least one of `--roles`/`--permissions`). |
+| `blocks iam users access grant <userId> [--roles a,b] [--permissions a,b] [--organization-id] [--dry-run] [--yes] [--json]` | Grants roles/permissions/org access (requires at least one of `--roles`/`--permissions`). A non-empty list **replaces** that organization's current list; an omitted one is kept. The dry-run prints `current` -- pass the complete set the user should end up with. |
 | `blocks iam users access revoke <userId> [--organization-id] [--dry-run] [--yes] [--json]` | Revokes org access for a user. |
 
 Command segments joined by a space also accept a colon
@@ -123,6 +123,7 @@ Apply the same confirm-before-mutating discipline here as with the SDK: state wh
 
 - **`list` is a POST**, not a GET — don't assume query-string filtering.
 - **Roles are referenced by slug**, as defined in blocks-iam-access-control — not by their internal item ids.
+- **A user holding the right role can still get 403** — that means the *role* is missing the endpoint permission, not that the user assignment failed. Granting it is blocks-iam-access-control's job (built-in/`clouduser`-held permissions are fully assignable to any role), not a reason to hand the user a broader role.
 - **`organizationId`** matters in multi-org projects — pass it to `get` when you need a user's record in a specific org context.
 - **Every request/response type in the SDK is a loosely-typed `Record<string, unknown>`** (`BlocksUser`, `BlocksBaseResponse`, etc. only guarantee a few common fields) — treat fields defensively and confirm shape against a live response for the project rather than assuming a fixed schema.
 - **The CLI user-admin surface is project-scoped** — `blocks iam users *`/`blocks iam email available` need a selected project and an impersonated project token. `iam me` is different only because it can fall back to account auth when no project resolves.

--- a/blocks-skills/blocks-localization-configuration/SKILL.md
+++ b/blocks-skills/blocks-localization-configuration/SKILL.md
@@ -93,13 +93,13 @@ Pushing translations into an existing language and *configuring the tenant's set
 
 | Command | What it does |
 |---|---|
-| `blocks localization language save --language-name <n> --language-code <c> [--is-default] [--item-id <id>] [--dry-run] [--yes] [--json]` | Creates or updates a language. Omit `--item-id` to create a new one. Mutating, full dry-run/confirm gate. |
+| `blocks localization language save --language-name <n> --language-code <c> [--is-default] [--item-id <id>] [--dry-run] [--yes] [--json]` | Creates or updates a language (upsert by name). Omit `--item-id` to create a new one. Re-saving an existing language keeps its `isDefault` unless `--is-default`/`--is-default=false` is passed -- the endpoint would otherwise demote the default. Mutating, full dry-run/confirm gate. |
 | `blocks localization language delete <languageName> [--dry-run] [--yes] [--json]` | Deletes a language. Mutating. |
 | `blocks localization language set-default <languageName> [--dry-run] [--yes] [--json]` | Marks a language as the tenant default. Mutating. |
 | `blocks localization language list [--json]` | Lists all languages. Read-only. |
 | `blocks localization language list-for-tenant [--json]` | Lists languages configured for the current tenant. Read-only. |
 
-So "add German as a supported language for the tenant" is a real, supported request: `blocks localization language save --language-name German --language-code de-DE --dry-run`, get approval, then re-run with `--yes`. This is distinct from `localization push --language de-DE`, which stamps translations onto keys and doesn't touch the tenant's language configuration at all.
+This is distinct from `localization push --language de-DE`, which stamps translations onto keys and doesn't touch the tenant's language configuration at all.
 
 ## Managing modules directly
 
@@ -111,7 +111,7 @@ A module is still created implicitly by the first `localization push` into it, b
 | `blocks localization module list [--json]` | Lists all modules. Read-only. |
 | `blocks localization module list-for-tenant [--json]` | Lists modules configured for the current tenant. Read-only. |
 
-So "create a `billing` module with no keys yet" is directly supported: `blocks localization module save --module-name billing --dry-run` → approve → `--yes`. `localization push`'s implicit module creation is just a convenience on top of the same underlying call, not the only path to it.
+`localization push`'s implicit module creation is a convenience on top of the same underlying call, not the only path to it.
 
 ## Other localization commands
 
@@ -122,7 +122,7 @@ A few more commands round out the surface beyond push/pull/validate/language/mod
 | `blocks localization key translate-and-export --module-id <id> [--wait] [--output-type <0-5>] [--dry-run] [--yes] [--json]` | Composed flow: `translate-all` (machine-translates every untranslated key in the module) → if `--wait`, polls until the operation settles → `generate-uilm-file` → `uilm-export`. Without `--wait` the three steps just fire back-to-back. Mutating. |
 
 `--output-type` (here and on `key uilm-export`) is the export file format, zero-based: `0` Json (the default), `1` Xml, `2` Text, `3` Xlsx, `4` Csv, `5` Xlf. Leaving it off gives Json, so an agent that wants a spreadsheet has to pass `3` explicitly.
-| `blocks localization glossary save --name <n> [--item-id <id>] [--language <c>] [--type <t>] [--context <text>] [--additional-note <text>] [--is-global] [--module-ids a,b] [--dry-run] [--yes] [--json]` | Creates or updates a glossary term. Mutating. |
+| `blocks localization glossary save --name <n> [--item-id <id>] [--language <c>] [--type <t>] [--context <text>] [--additional-note <text>] [--is-global] [--module-ids a,b] [--dry-run] [--yes] [--json]` | Creates or updates a glossary term. With `--item-id` the current term is read and merged -- the endpoint rebuilds it from the body, so language/type/context/note/module tags would otherwise be dropped. Mutating. |
 | `blocks localization glossary list [--search <text>] [--module-id <id>] [--is-global] [--page-number <n>] [--page-size <n>] [--json]` | Lists glossary terms. Read-only. |
 | `blocks localization glossary get <itemId> [--json]` | Fetches one glossary term. Read-only. |
 | `blocks localization glossary suggested <itemId> [--max-results <n>] [--json]` | Suggests glossary terms relevant to an item. Read-only. |
@@ -133,7 +133,6 @@ A few more commands round out the surface beyond push/pull/validate/language/mod
 
 ## Gotchas
 
-- **`--dry-run` before `--yes`** on `localization push` — always. Same pattern as every other mutating `blocks` command.
 - **`--language` on `push` is not validated against configured cultures.** `localization push` stamps whatever string you pass as `--language` directly into each key's `culture` field — it does not check that culture against the tenant's actual configured languages, and doesn't call `language list`/`list-for-tenant` to look. Get the culture code wrong (`de` instead of `de-DE`, or a culture the tenant never configured via `language save`) and the key saves without error but may never surface at runtime, because runtime lookups match by the tenant's real configured `languageCode`. Confirm the exact culture code with the user (or run `localization language list-for-tenant`) before pushing, especially for less common languages like Bengali (`bn-BD` vs `bn`).
 - **Module auto-create is silent and permanent.** The first push against a new `--module` name creates it with no separate confirmation prompt beyond the push's own `--dry-run`/`--yes` gate — `--dry-run` output will tell you a module lookup happened, but won't distinguish "will create" from "already exists" as clearly as it could, so read the dry-run JSON's module info carefully, or ask the user to confirm the module name is intentional (typos become new, mostly-empty modules). Prefer `localization module save` first if the user wants the module created deliberately, without an accompanying key push.
 - **`localization validate` is local-only** — it confirms the JSON is well-formed and keys/values pass the naming rules; it does not confirm the push will succeed against the server (module resolution, auth, project selection). Still run `--dry-run` on the actual push.
@@ -146,10 +145,5 @@ A few more commands round out the surface beyond push/pull/validate/language/mod
 - "Add German translations for my login screen." → push `login.de-DE.json` after validate + dry-run + approval.
 - "Add German and Bengali translations for my login screen." → two dictionary files, two validate/push pairs (`de-DE`, `bn-BD`), same module.
 - "Set up a `common` module for shared strings like Save/Cancel/Delete." → write `common.<language>.json` with those keys, validate, push (this is what creates the `common` module) — or use `localization module save --module-name common` directly if no keys exist yet.
-- "Pull the latest translations for the dashboard module before I edit them." → `localization pull --module dashboard --language en`.
-- "Validate my localization file before pushing." → `localization validate` only, no network call.
-- "Can we add Bengali as a new supported language for the tenant?" → `localization language save --language-name Bengali --language-code bn-BD --dry-run`, confirm, then `--yes`.
-- "Create a new translation module called `billing` with no keys yet." → `localization module save --module-name billing --dry-run` → confirm → `--yes`.
+- "Can we add Bengali as a new supported language for the tenant?" → `localization language save --language-name Bengali --language-code bn-BD --dry-run`, confirm, then `--yes` — a language-config change, not a `push`.
 - "Machine-translate the whole `login` module and give me the export." → `localization key translate-and-export --module-id <id> --wait --dry-run` → confirm → `--yes`.
-- "Suggest a translation for this button label." → `localization assistant translation-suggestion --source-text "Save changes" --destination-language-code de-DE`.
-- "What's our webhook config for localization events?" → `localization config get-webhook`.

--- a/blocks-skills/blocks-mail/SKILL.md
+++ b/blocks-skills/blocks-mail/SKILL.md
@@ -47,6 +47,7 @@ Everything under `mail config`, `mail template`, and `mail mailbox` is project-s
 - **`blocks mail config list [--json]`** — read-only.
 - **`blocks mail config get <name> [--json]`** — read-only (positional arg, or `--name`).
 - **`blocks mail config save [--configuration-id <id>] [--name <n>] [--host <h>] [--port <p>] [--enable-ssl] [--inbound] [--provider <n>] [--sender-name <n>] [--sender-address <addr>] [--sender-username <u>] [--account-password <p>] [--body '<json>'|--file <path>] [--dry-run] [--yes] [--json]`** — the create-or-update call for a mail server, so omitting `--configuration-id` is what makes it a new one. `--provider` and `--port` are raw integers (the CLI doesn't document the provider enum's meaning — don't guess a value). `--account-password` is redacted (`***`) in `--dry-run` output only; the live response and stored value are still sensitive.
+- Updating (`--configuration-id`) reads the stored configuration and merges, so `--enable-ssl`/`--inbound`/`--provider` survive a host-only change. `--account-password` must still be passed on every update: the server requires it and returns it masked, so it cannot be carried.
 - **`blocks mail config delete <configurationId> [--dry-run] [--yes] [--json]`**
 - **`blocks mail config duplicate <configurationId> [--dry-run] [--yes] [--json]`**
 

--- a/blocks-skills/blocks-notification/SKILL.md
+++ b/blocks-skills/blocks-notification/SKILL.md
@@ -26,6 +26,8 @@ blocks notification save --name <n> --channel <0|1> --type <0-3> --yes --json   
 blocks notification save --update --body '<json>' --yes --json                       # full custom payload
 ```
 
+Save upserts by `--name` and the CLI reads the existing configuration first, so re-saving to change one of `--channel`/`--type`/`--enable-persistence` keeps the other two (the endpoint itself stores whatever the body says, defaults included).
+
 The request body is built by merging (in this order, later keys win) whatever `--body '<json>'` or `--file <path.json>` supplies, then these convenience flags layered on top (so an unset convenience flag never overwrites a value from `--body`/`--file`):
 
 | Flag | Body field | Notes |
@@ -33,7 +35,7 @@ The request body is built by merging (in this order, later keys win) whatever `-
 | `--channel <int>` | `channelToNotify` | Raw integer — the CLI does **not** validate or enum-check the value itself. |
 | `--type <int>` | `notificationType` | Same — raw integer, no validation in the command. |
 | `--enable-persistence[=false]` | `enablePersistence` | Presence sends `true`; `--enable-persistence=false` sends `false`; omission leaves it out. |
-| `--update` | `isUpdateRequest` | Same true-only pattern as `--enable-persistence`. Set this when saving over an existing config rather than creating a new one. |
+| `--update` | `isUpdateRequest` | Same true-only pattern as `--enable-persistence`. Usually unnecessary: when `--name` matches an existing config (exact case), the CLI sets `isUpdateRequest: true` itself — without it the server rejects the save as a duplicate name. Pass `--update=false` only to force create semantics. |
 | `--name <text>` | `name` | |
 | `--notify-method <text>` | `notifyMethod` | |
 
@@ -55,7 +57,7 @@ Same `itemId` resolution as `get` — positional arg or `--id`, one required. `-
 - **No SDK path, ever.** If asked "how do I manage notification channels from my app," the answer is: you don't — this is CLI-only, human/CI-operated configuration, not something to wire into frontend or backend app code.
 - **`notification` and `notifier` are not the same thing.** `notification save/list/get/delete` (this skill) configures *which channel/method* a notification type uses. `notifier notify/list/unread/mark-read/mark-all-read` *sends* notifications and reads a user's inbox — a separate command family with its own commands, not covered here. Don't answer a "send a notification" request with `notification save`, and don't answer a "configure the notification channel" request with `notifier`.
 - **`list` and `get` have no `--dry-run`.** Only `save` and `delete` build a request that's worth previewing; the two read commands hit the API directly. Don't tell a user to `--dry-run` a `list` or `get` call.
-- **Boolean payload flags preserve explicit false.** `--enable-persistence=false` and `--update=false` send `false`; omitting either leaves the field out. Prefer omitting `--update` for a create rather than sending a redundant false.
+- **Boolean payload flags preserve explicit false.** `--enable-persistence=false` and `--update=false` send `false`; omitting either leaves the field out — except `isUpdateRequest`, which the CLI adds itself when the name already exists (an update would otherwise be rejected as a duplicate name). Name matching is exact, case included.
 - **`--channel`/`--type` are unvalidated raw integers.** The command will happily send any integer you give it — there's no local check against the underlying enums. Confirm the intended value with the user (or check the Blocks portal/API docs) rather than inventing one.
 - **`itemId` for `get`/`delete` is always required**, positional or `--id` — never guessed. Ask the user rather than assuming a value.
 - **Every command is project-scoped.** All four require a resolved project and an impersonated project token; behavior follows whichever project is currently selected via `blocks use` (or an explicit `--project` override).
@@ -66,6 +68,6 @@ Same `itemId` resolution as `get` — positional arg or `--id`, one required. `-
 - "List the notification channel configs for this project."
 - "Get notification config `<itemId>`."
 - "Save a new notification config named `<name>` on channel 0, type 1." → preview with `--dry-run` first.
-- "Update the existing `<name>` notification config." → add `--update`, still `--dry-run` before `--yes`.
+- "Update the existing `<name>` notification config." → just re-save with the exact same name (the CLI merges the stored values and marks it as an update itself), `--dry-run` before `--yes`.
 - "Delete notification config `<itemId>`."
 - "Send a notification to these users" / "show me a user's unread notifications" → not this skill; that's `blocks notifier *`, a different command family for sending/reading, not channel configuration.

--- a/blocks-skills/blocks-notifier/SKILL.md
+++ b/blocks-skills/blocks-notifier/SKILL.md
@@ -53,7 +53,7 @@ OrderBy
 
 CLI flags map to them as `--user-id` -> `UserId`, `--context` -> `SubscriptionFilterData.Context`, `--action-name` -> `SubscriptionFilterData.ActionName`, `--value` -> `SubscriptionFilterData.Value`, `--order-by` -> `OrderBy` (`1` = CreatedTime, newest first; `2` = ReadStatus — unread grouped ahead of read).
 
-This flattening is a **client-side inference, not something verified against a live call** — both the CLI and SDK made the same choice independently, which is corroborating but not proof the real backend accepts it. If a live `notifier unread` call ever errors, re-check this against the actual API response rather than assuming the flattening above is still correct.
+This flattening is a **best-effort workaround, and the backend does not currently honor it**: the service declares this read as taking its filter in the request body, so query parameters do not reach the filter at all — expect a missing-body rejection (or an unfiltered result) until the service is changed to read the filter from the query string. Prefer `blocks notifier list --unread-only` for "what's unread"; keep `unread` for the day the server side is fixed, and if a live call errors, that is why.
 
 ## SDK — `blocksClient.notifier.*`
 


### PR DESCRIPTION
….4.1)

Ten save/update commands read the current record and merge so omitted fields are no longer wiped (shared helper src/lib/merge-current.ts); notification save marks existing names as updates; mail save carries isEnableSnsConfiguration; language/notification name matching is exact, like the servers' lookups. iam users update follows blocks-iam's new sparse-patch contract and rejects retired roles/permissions/MFA fields. Release commands and logout drop the stale /api base segment; storage config delete uses POST as the endpoint declares. Adds scripts/verify-endpoints.mjs (npm run verify:endpoints) to check every CLI route+verb against the checked-out service controllers; skills and agent docs updated to match, with repetition trims in the three largest.